### PR TITLE
Modularise national and place-level views, add national engagement visualisation and introduced data-age display

### DIFF
--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -1975,3 +1975,245 @@ display_national_data_coverage_table <- function(df) {
     )
   )
 }
+
+#' Prepare national-level engagement data
+#'
+#' @description
+#' This function takes a long-format dataset of cohort and engagement metrics
+#' and produces a monthly summary suitable for plotting national-level
+#' engagement trends. It returns one row per month with:
+#' - total cohort size
+#' - number of contributing places
+#' - total engaged population
+#' - number of places with active engagement
+#' - engagement rates
+#' - formatted hover text for visualisation
+#'
+#' @param df A tibble or data frame containing metric data.
+#'
+#' @returns A data frame with one row per month and derived engagement metrics
+#'
+#' @examples
+#' \dontrun{
+#' get_data_for_national_engagement(df = df)
+#' }
+get_data_for_national_engagement <- function(df) {
+  # get details for the total number of people in the cohort each month
+  part1_cohort <-
+    df |>
+    dplyr::filter(
+      demographic_type == "Total",
+      value_type == "patients",
+      !is.na(value) # need to do this in case a place left all blank
+    ) |>
+    # summarise
+    dplyr::summarise(
+      .by = month_zoo,
+      cohort_size = sum(value, na.rm = TRUE),
+      n_places = dplyr::n_distinct(place, na.rm = TRUE)
+    )
+
+  # get details for the total number of people engaged each month
+  part2_engaged <-
+    df |>
+    dplyr::filter(
+      demographic_type == "Total",
+      metric_id == "P1"
+    ) |>
+    # summarise
+    dplyr::summarise(
+      .by = month_zoo,
+      engaged_pop = sum(value, na.rm = TRUE),
+      n_places_engaged = sum(flag_actively_engaged, na.rm = TRUE)
+    )
+
+  # combine the two data and prepare for plotting
+  df_return <-
+    dplyr::left_join(
+      x = part1_cohort,
+      y = part2_engaged,
+      by = dplyr::join_by(x$month_zoo == y$month_zoo)
+    ) |>
+    dplyr::mutate(
+      month_zoo = month_zoo |> zoo::as.yearmon(),
+      month_dt = month_zoo |> zoo::as.Date(frac = 0),
+
+      # derived metrics
+      engagement_rate = engaged_pop / cohort_size,
+      place_engagement_rate = n_places_engaged / n_places,
+
+      # hover text for {plotly}
+      hover_text = glue::glue(
+        "<b>{month_zoo}</b>
+      Target cohort: <b>{prettyunits::pretty_num(cohort_size)}</b>
+      Engaged population: <b>{prettyunits::pretty_num(engaged_pop)}</b>
+      Engagement rate: <b>{scales::percent(engagement_rate)}</b>
+      Places engaging: <b>{n_places_engaged}</b> out of <b>{n_places}</b> (<b>{scales::percent(place_engagement_rate, accuracy = 1)}</b>)
+      "
+      )
+    )
+
+  return(df_return)
+}
+
+#' Display national engagement plot with procedural annotations
+#'
+#' @description
+#' This function takes a monthly engagement dataset (as produced by `get_data_for_national_engagement()`) and generates a {plotly} visual showing cohort size, engaged population and a set of automatically detected milestone annotations.
+#'
+#' @param df A data frame containing:
+#' - month_dt (Date)
+#' - cohort_size
+#' - engaged_pop
+#' - engagement_rate
+#' - place_engagement_rate
+#' - hover_text
+#'
+#' @returns A {plotly} object
+display_national_engagement_plot <- function(df) {
+  # define a function to add annotations to a list
+  add_annotation_to_list <- function(df, idx = NA, str_desc = "") {
+    # if rule is not met then ignore
+    if (is.na(idx)) {
+      return(ann_list)
+    }
+
+    # construct an annotation
+    new_x <- df$month_dt[idx]
+    new_y <- df$engaged_pop[idx]
+
+    # count how many existing annotations already use this point
+    same_point_count <- sum(vapply(
+      ann_list,
+      function(a) a$x == new_x && a$y == new_y,
+      logical(1)
+    ))
+
+    # offset each additional annotation by 20px downward
+    offset <- same_point_count * 20
+
+    # construct the annotation
+    annotation <- list(
+      x = df$month_dt[idx],
+      y = df$engaged_pop[idx],
+      text = str_desc,
+      showarrow = TRUE,
+      arrowhead = 2,
+      xanchor = "right",
+      ax = -20,
+      ay = -40 - offset # progressively shift down
+    )
+
+    return(append(ann_list, list(annotation)))
+  }
+
+  # start the annotations list
+  ann_list <- list()
+
+  # engagement rate thresholds
+  thresholds <- c(
+    "Engagement > 10%" = 0.10,
+    "Engagement > 20%" = 0.20,
+    "Engagement > 50%" = 0.50,
+    "Engagement > 80%" = 0.80
+  )
+
+  for (label in names(thresholds)) {
+    idx <- which(df$engagement_rate > thresholds[[label]])[1]
+    ann_list <- add_annotation_to_list(df = df, idx = idx, str_desc = label)
+  }
+
+  ## rule: engagement rate slows
+  rate_diff <- diff(df$engagement_rate)
+  idx <- which(rate_diff < 0)[1] + 1
+  ann_list <- add_annotation_to_list(
+    df = df,
+    idx = idx,
+    str_desc = "Engagement rate growth slows"
+  )
+
+  ## rule: largest month-on-month increase
+  # mom <- diff(df$engaged_pop)
+  # idx <- which.max(mom) + 1
+  # ann_list <- add_annotation_to_list(
+  #   df = df,
+  #   idx = idx,
+  #   str_desc = "Largest month-on-month increase"
+  # )
+
+  ## rule: engagement rate doubles from baseline
+  base <- df$engaged_pop[1] / df$cohort_size[1]
+  rate <- df$engaged_pop / df$cohort_size
+  idx <- which(rate >= 2 * base)[1]
+  ann_list <- add_annotation_to_list(
+    df = df,
+    idx = idx,
+    str_desc = "Engagement rate 2x baseline"
+  )
+
+  # engaged population thresholds
+  pop_thresholds <- c(
+    "Engaged population > 100k" = 1e5L,
+    "Engaged population > 200k" = 2e5L
+  )
+
+  for (label in names(pop_thresholds)) {
+    idx <- which(df$engaged_pop > pop_thresholds[[label]])[1]
+    ann_list <- add_annotation_to_list(df = df, idx = idx, str_desc = label)
+  }
+
+  # place engagement thresholds
+  place_thresholds <- c(
+    "Engagement > 50% of places" = 0.50,
+    "Engagement > 80% of places" = 0.80
+  )
+
+  for (label in names(place_thresholds)) {
+    idx <- which(df$place_engagement_rate > place_thresholds[[label]])[1]
+    ann_list <- add_annotation_to_list(df = df, idx = idx, str_desc = label)
+  }
+
+  # construct the plot
+  plotly::plot_ly(
+    data = df,
+    x = ~month_dt,
+    hoverinfo = "text",
+    text = ~hover_text
+  ) |>
+    plotly::add_trace(
+      y = ~cohort_size,
+      type = "scatter",
+      mode = "lines",
+      name = "Cohort",
+      line = list(shape = "hv", color = "#5881c1")
+    ) |>
+    plotly::add_trace(
+      y = ~engaged_pop,
+      type = "scatter",
+      mode = "markers+lines+fill",
+      name = "Engaged",
+      line = list(shape = "hv", color = "#f9bf07"),
+      marker = list(
+        color = "#f9bf07",
+        size = 12,
+        line = list(color = "#fff", width = 2)
+      ),
+      fillcolor = adjustcolor("#f9bf07", alpha.f = 0.3),
+      fill = "tozeroy"
+    ) |>
+    plotly::layout(
+      # ensure x-axis displays one tick per month
+      xaxis = list(
+        tickformat = "%b %Y",
+        dtick = "M1",
+        title = "Submission period"
+      ),
+      yaxis = list(title = ""),
+      # add the annotations to the plot
+      annotations = ann_list,
+      # general config
+      showlegend = FALSE,
+      font = list(family = "Roboto, Arial, sans-serif", size = 16)
+    ) |>
+    plotly::config(displaylogo = FALSE)
+}

--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -1253,6 +1253,196 @@ compute_funnel_limits <- function(df_funnel) {
     )
 }
 
+#' Build the place engagement table data
+#'
+#' @description
+#' This function prepares the dataset required for the place-level engagement table in the dashboard. It produces one row per place, containing:
+#' - `cohort_size` - the most recent estimate of the number of patients in the target cohort (value_type = "patients", demographic_type = "Total")
+#' - monthly engagement counts (metric P1), pivoted wide so that each month appears as a separate column.
+#' - `engagement_rate` - the proportion of the cohort engaged in the most recent month, calculated as:
+#'
+#' engagement_num / patients_latest
+#'
+#' where:
+#' - `patients_latest` is the maximum reported patient count in the latest month for each place (taken across all metrics that report it).
+#' - `engagement_num` is the P1 engagement count for the latest month. If a place has only missing values for P1, the numerator is treated as 0.
+#'
+#' @param df A tibble of metric data.
+#'
+#' @returns A tibble with one row per place and columns:
+#' - `place`,
+#' - `cohort_size`,
+#' - monthly engagement counts
+#' - `engagement_rate`
+#'
+#' @examples
+#' \dontrun{
+#' engagement_table <- get_data_for_engagement_table(df = df)
+#' }
+get_data_for_engagement_table <- function(df) {
+  # get the cohort size (most recent month)
+  part1_cohort <-
+    df |>
+    dplyr::filter(
+      demographic_type == "Total",
+      value_type == "patients",
+      !is.na(value)
+    ) |>
+    dplyr::group_by(place) |>
+    dplyr::filter(month_zoo == max(month_zoo, na.rm = TRUE)) |>
+    dplyr::summarise(cohort_size = max(value, na.rm = TRUE), .groups = "drop")
+
+  # get the number of people engaged each month
+  part2_engagement_month <-
+    df |>
+    dplyr::filter(metric_id == "P1", demographic_type == "Total") |>
+    dplyr::distinct(place, month_zoo, value) |>
+    tidyr::pivot_wider(
+      names_from = month_zoo,
+      values_from = value
+    )
+
+  # get the engagement rate for the latest month
+  # start with the denominator (latest values for the cohort)
+  part3_engagement_rate_denom <-
+    df |>
+    # keep only rows that can contribute to the denominator
+    dplyr::filter(
+      demographic_type == "Total",
+      value_type == "patients",
+      !is.na(value)
+    ) |>
+    # get the latest month per place
+    dplyr::group_by(place) |>
+    dplyr::filter(month_zoo == max(month_zoo, na.rm = TRUE)) |>
+    # take the most reliable denominator (max value)
+    dplyr::summarise(
+      patients_latest = max(value, na.rm = TRUE),
+      .groups = "drop"
+    )
+
+  # next is the engaged proportion (latest values per place)
+  part3_engagement_rate_num <-
+    df |>
+    # keep only rows that can contribute to the numerator
+    dplyr::filter(metric_id == "P1", demographic_type == "Total") |>
+    # get the latest month per place
+    dplyr::group_by(place) |>
+    dplyr::filter(month_zoo == max(month_zoo, na.rm = TRUE)) |>
+    dplyr::summarise(
+      engagement_num = max(tidyr::replace_na(value, 0)),
+      .groups = "drop"
+    )
+
+  # join these together and work out the rate
+  part3_engagement_rate <-
+    dplyr::left_join(
+      x = part3_engagement_rate_denom,
+      y = part3_engagement_rate_num,
+      by = dplyr::join_by(x$place == y$place)
+    ) |>
+    dplyr::mutate(engagement_rate = engagement_num / patients_latest) |>
+    dplyr::select(place, engagement_rate)
+
+  # combine the components to the output
+  tibble::tibble(place = expected_places) |>
+    # add in the cohort size
+    dplyr::left_join(
+      y = part1_cohort,
+      by = dplyr::join_by(x$place == y$place)
+    ) |>
+    # add in monthly engagement rate
+    dplyr::left_join(
+      y = part2_engagement_month,
+      by = dplyr::join_by(x$place == y$place)
+    ) |>
+    # add in latest engagement rate
+    dplyr::left_join(
+      y = part3_engagement_rate,
+      by = dplyr::join_by(x$place == y$place)
+    )
+}
+
+#' Render the place-level engagement reactable table
+#'
+#' @description
+#' This function creates an interactive {reactable} table for displaying
+#' place-level engagement data. It is designed for use in the dashboard and
+#' includes several usability enhancements:
+#' - **Sticky header row** - remains visible when scrolling vertically
+#' - **Sticky left column** - the `place` column stays fixed when scrolling
+#'   horizontally across many month columns
+#' - **Automatic numeric formatting** - all numeric columns (including month
+#'   columns and cohort sizes) are right-aligned, formatted as integers and
+#'   constrained to a reasonable maximum width.
+#' - **Percentage formatting** - the `engagement_rate` column is displayed as
+#'   a percentage with one decimal place
+#' - **Horizontal scrolling** - enabled via `fullWidth = FALSE`, ensuring wide
+#'   tables remain readable
+#'
+#' @param df A tibble of metric data.
+#'
+#' @returns A {reactable} widget suitable for display in a Shiny app or R
+#' Markdown dashboard.
+display_engagement_table <- function(df) {
+  # get the engagement data
+  df_engagement <- get_data_for_engagement_table(df = df)
+
+  df_engagement |>
+    reactable::reactable(
+      pagination = FALSE,
+      highlight = TRUE,
+      resizable = TRUE,
+      wrap = FALSE,
+      fullWidth = FALSE, # enables horizontal scrolling
+
+      # default column behaviour
+      defaultColDef = reactable::colDef(
+        align = "right",
+        format = reactable::colFormat(digits = 0, separators = TRUE),
+        minWidth = 90,
+        maxWidth = 100
+      ),
+
+      # column formating
+      columns = list(
+        place = reactable::colDef(
+          sticky = "left",
+          header = "Place",
+          align = "left",
+          # width = 250,
+          minWidth = 180,
+          maxWidth = 1000
+        ),
+
+        cohort_size = reactable::colDef(
+          header = "Cohort size",
+          minWidth = 110,
+          maxWidth = 120
+        ),
+
+        engagement_rate = reactable::colDef(
+          header = "Engagement rate",
+          format = reactable::colFormat(percent = TRUE, digits = 1),
+          minWidth = 150,
+          maxWidth = 160,
+          align = "right"
+        )
+      ),
+      theme = reactable::reactableTheme(
+        style = list(
+          headerStyle = list(
+            position = "sticky",
+            top = 0,
+            zIndex = 3,
+            background = "#fff"
+          ),
+          fontFamily = "Roboto, Arial, sans-serif"
+        )
+      )
+    )
+}
+
 
 # National views --------------------------------------------------------------
 

--- a/outputs/reporting_app/R/mod_national_changelog.R
+++ b/outputs/reporting_app/R/mod_national_changelog.R
@@ -26,7 +26,6 @@ mod_national_changelog_ui <- function(id) {
 # server ----
 mod_national_changelog_server <- function(id, df_issues) {
   shiny::moduleServer(id, function(input, output, session) {
-    # code goes here
     output$changelog_table <- reactable::renderReactable({
       req(df_issues())
 

--- a/outputs/reporting_app/R/mod_national_changelog.R
+++ b/outputs/reporting_app/R/mod_national_changelog.R
@@ -1,0 +1,36 @@
+# --- Changelog (National) ----------------------------------------------------
+
+# ui ----
+mod_national_changelog_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the UI
+  bslib::nav_panel(
+    title = "Change log",
+    icon = bsicons::bs_icon("journal-text"),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      sidebar = bslib::sidebar(
+        open = FALSE,
+        shiny::includeMarkdown("descriptions/national_changelog.md")
+      ),
+      bslib::card_body(
+        reactable::reactableOutput(ns("changelog_table")),
+        fill = TRUE
+      )
+    )
+  )
+}
+
+# server ----
+mod_national_changelog_server <- function(id, df_issues) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # code goes here
+    output$changelog_table <- reactable::renderReactable({
+      req(df_issues())
+
+      display_issueslog(df_issues = df_issues())
+    })
+  })
+}

--- a/outputs/reporting_app/R/mod_national_coverage.R
+++ b/outputs/reporting_app/R/mod_national_coverage.R
@@ -1,0 +1,35 @@
+# --- Data coverage -----------------------------------------------------------
+
+# ui ----
+mod_national_coverage_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the UI
+  bslib::nav_panel(
+    title = "Data coverage",
+    icon = bsicons::bs_icon("ui-checks-grid"),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      sidebar = bslib::sidebar(
+        open = FALSE,
+        shiny::includeMarkdown("descriptions/national_coverage.md")
+      ),
+      bslib::card_body(
+        reactable::reactableOutput(ns("national_data_coverage_table")),
+        fill = TRUE
+      )
+    )
+  )
+}
+
+# server ----
+mod_national_coverage_server <- function(id, df) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # national data coverage table
+    output$national_data_coverage_table <- reactable::renderReactable({
+      shiny::req(df())
+      display_national_data_coverage_table(df = df())
+    })
+  })
+}

--- a/outputs/reporting_app/R/mod_national_engagement.R
+++ b/outputs/reporting_app/R/mod_national_engagement.R
@@ -1,0 +1,36 @@
+# --- Engagement (National) ---------------------------------------------------
+
+# ui ----
+mod_national_engagement_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the ui
+  bslib::nav_panel(
+    title = "Engagement",
+    icon = bsicons::bs_icon("graph-up"),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      open = FALSE,
+      sidebar = bslib::sidebar(
+        open = FALSE,
+        shiny::includeMarkdown("descriptions/national_engagement.md")
+      ),
+      bslib::card_body(
+        plotly::plotlyOutput(ns("engagement_plot"))
+      )
+    )
+  )
+}
+
+# server ----
+mod_national_engagement_server <- function(id, df) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # update the plot
+    output$engagement_plot <- plotly::renderPlotly({
+      req(df())
+      plot_data <- get_data_for_national_engagement(df = df())
+      display_national_engagement_plot(df = plot_data)
+    })
+  })
+}

--- a/outputs/reporting_app/R/mod_national_overview.R
+++ b/outputs/reporting_app/R/mod_national_overview.R
@@ -1,0 +1,45 @@
+# --- Overview (national) -----------------------------------------------------
+
+# ui ----
+mod_national_overview_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the ui
+  bslib::nav_panel(
+    title = "Overview",
+    icon = bsicons::bs_icon("table"),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      sidebar = bslib::sidebar(
+        open = FALSE,
+        shiny::includeMarkdown("descriptions/national_overview.md")
+      ),
+      bslib::card_body(
+        reactable::reactableOutput(ns("national_table")),
+        fill = TRUE
+      )
+    )
+  )
+}
+
+# server ----
+mod_national_overview_server <- function(
+  id,
+  df,
+  month_current,
+  month_previous
+) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # code goes here
+    output$national_table <- reactable::renderReactable({
+      req(df(), month_current(), month_previous())
+
+      display_dashboard_national(
+        df = df(),
+        month_latest = month_current(),
+        month_prev = month_previous()
+      )
+    })
+  })
+}

--- a/outputs/reporting_app/R/mod_place_engagement.R
+++ b/outputs/reporting_app/R/mod_place_engagement.R
@@ -1,0 +1,35 @@
+# --- Engagement (Places) -----------------------------------------------------
+
+# ui ----
+mod_place_engagement_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the UI
+  bslib::nav_panel(
+    title = "Engagement",
+    icon = bsicons::bs_icon("table"),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      open = FALSE,
+      sidebar = bslib::sidebar(
+        open = FALSE,
+        shiny::includeMarkdown("descriptions/place_engagement.md")
+      ),
+      bslib::card_body(
+        reactable::reactableOutput(ns("engagement_table"))
+      )
+    )
+  )
+}
+
+# server ----
+mod_place_engagement_server <- function(id, df) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # update the table
+    output$engagement_table <- reactable::renderReactable({
+      req(df())
+      display_engagement_table(df = df())
+    })
+  })
+}

--- a/outputs/reporting_app/R/mod_place_funnel.R
+++ b/outputs/reporting_app/R/mod_place_funnel.R
@@ -1,0 +1,80 @@
+# --- Funnel plot for Places --------------------------------------------------
+
+# ui -----
+mod_place_funnel_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the UI
+  bslib::nav_panel(
+    title = "Funnel plot",
+    icon = bsicons::bs_icon("funnel"),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      sidebar = bslib::sidebar(
+        open = FALSE,
+        shiny::includeMarkdown("descriptions/place_funnel.md")
+      ),
+      bslib::card_body(
+        plotly::plotlyOutput(
+          ns("place_funnel_plot"),
+          height = "100%",
+          fill = TRUE
+        ),
+        fill = TRUE,
+        height = "100%"
+      )
+    )
+  )
+}
+
+# server ----
+mod_place_funnel_server <- function(id, df, place, metric, month, df_version) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # cache funnel data for month:metric for improved UX ----
+    df_funnel <- shiny::reactive({
+      req(df(), df_version(), month(), metric(), place())
+
+      get_data_for_funnel_plot(
+        df = df(),
+        month_selected = month(),
+        metric_selected = metric()
+      )
+    }) |>
+      shiny::bindCache(
+        df_version(),
+        month(),
+        metric()
+      )
+
+    # cache limits data for month:metric for improved UX ----
+    df_limits <- shiny::reactive({
+      req(df_funnel())
+
+      compute_funnel_limits(df_funnel = df_funnel())
+    }) |>
+      shiny::bindCache(
+        df_version(),
+        month(),
+        metric()
+      )
+
+    # render the funnel ----
+    output$place_funnel_plot <- plotly::renderPlotly({
+      req(
+        df(),
+        df_funnel(),
+        place(),
+        metric()
+      )
+
+      get_funnel_plot(
+        df_funnel = df_funnel(),
+        df_limits = df_limits(),
+        place_selected = place(),
+        metric_selected = metric(),
+        month_selected = month()
+      )
+    })
+  })
+}

--- a/outputs/reporting_app/R/mod_place_overview.R
+++ b/outputs/reporting_app/R/mod_place_overview.R
@@ -1,0 +1,51 @@
+# --- Overview (Places) -------------------------------------------------------
+
+# ui ----
+mod_place_overview_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the UI
+  bslib::nav_panel(
+    title = "Overview",
+    icon = bsicons::bs_icon("table"),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      sidebar = bslib::sidebar(
+        open = FALSE,
+        shiny::includeMarkdown("descriptions/place_overview.md")
+      ),
+      bslib::card_body(
+        reactable::reactableOutput(ns("place_table")),
+        fill = TRUE
+      )
+    )
+  )
+}
+
+# server ----
+mod_place_overview_server <- function(
+  id,
+  df,
+  place,
+  month_current,
+  month_previous
+) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # update the table
+    output$place_table <- reactable::renderReactable({
+      req(
+        df(),
+        place(),
+        month_current(),
+        month_previous()
+      )
+      display_dashboard(
+        df = df(),
+        place_selected = place(),
+        month_latest = month_current(),
+        month_prev = month_previous()
+      )
+    })
+  })
+}

--- a/outputs/reporting_app/R/mod_utils_last_updated.R
+++ b/outputs/reporting_app/R/mod_utils_last_updated.R
@@ -1,0 +1,33 @@
+# --- Data last updated (utils) -----------------------------------------------
+
+# ui ----
+mod_utils_last_updated_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the UI
+  bslib::card(
+    class = "p-2 text-center",
+    uiOutput(ns("pin_last_updated"))
+  )
+}
+
+# server ----
+mod_utils_last_updated_server <- function(id, time) {
+  shiny::moduleServer(id, function(input, output, session) {
+    output$pin_last_updated <- shiny::renderUI({
+      req(time())
+      t <- time()
+      if (inherits(t, "Date")) {
+        t <- as.POSIXct(t)
+      }
+      str_ago <- t |> prettyunits::time_ago()
+      str_rtn <- glue::glue("Last refreshed {str_ago}")
+      span(
+        class = "text-muted small",
+        icon("clock"),
+        str_rtn
+      )
+    })
+  })
+}

--- a/outputs/reporting_app/descriptions/national_changelog.md
+++ b/outputs/reporting_app/descriptions/national_changelog.md
@@ -1,0 +1,34 @@
+## Issues and changes log
+
+This table provides a record of issues, observations and changes identified during the data-ingestion process. It is designed to support **shared learning**, improve transparency and help teams understand how data processing evolves over time.
+
+### What the table shows
+
+- **Reporting month**
+  The submission month in which the issues was identified or logged.
+
+- **Event type**
+  A broad category describing the nature of the issue or change (e.g., template issues, unexpected demographics, missing denominators).
+
+- **Place affected**
+  The Place associated with the issue, where relevant. Some issues may relate to multiple Places or to the ingestion pipeline more generally.
+
+- **Description**
+  A short explanation of what was observed. This may include examples, context or details about how the issue was identified.
+
+- **Impact**
+  A description of how the issue affected data ingestion or interpretation. This is not a judgement of severity - it simply summarises the practical implications (e.g. delayed processing, missing fields, unexpected values).
+
+- **Resolution / Action taken**
+  Notes on how the issue was addressed, or steps taken to improve the ingestion process. This helps build a shared understanding of what has already been resolved and what may require further attention.
+
+- **Status**
+  A simple indicator of whether the issue is open, resolved or under review.
+
+### Why this view is useful
+
+- Encourages shared learning across teams by documenting what has been observed and how it has been addressed.
+- Provides a transparent record of changes to the ingestion process, helping you understand why data may look different across months.
+- Helps identify recurring themes or areas where additional guidance or process improvements may be helpful.
+- Supports consistent communication by keeping all issue-related information in one accessible place.
+

--- a/outputs/reporting_app/descriptions/national_coverage.md
+++ b/outputs/reporting_app/descriptions/national_coverage.md
@@ -1,0 +1,28 @@
+## National data coverage table
+
+This table provides an overview of **which Places have processed data available for each reporting month**. It is designed to give a clear, at-a-glance view of data coverage across all Places, helping you understand where submissions are present and where gaps exist.
+
+### What the table shows
+
+- **Places as rows**
+  Every NNHIP Place is included, even if no processed data is available for some months.
+
+- **Months as columns**
+  Each column represents a reporting month included in the dataset.
+
+- **Checkmarks for processed submissions**
+  A ✔️ symbol indicates that processed data is available for that Place in that month. Empty cells simple mean that no processed data is present for that Place-month combination.
+
+- **Sticky Place column**
+  The left-hand Place column remains visible while scrolling horizontally, making it easier to navigate across months.
+
+- **Search, sorting and highlighting**
+  The table supports quick filtering, sorting by Place and row highlighting to help you explore the data more easily.
+
+### Why this view is useful
+
+- Provides a transparent overview of data availability across all Places.
+- Helps identify gaps in processed submissions, which may arise for many reasons (e.g., timing, data quality checks or local processing schedules).
+- Supports interpretation of other dashboard views by showing the underlying data coverage.
+- Ensures that all Places are represented, even when data is not yet available for every month.
+

--- a/outputs/reporting_app/descriptions/national_engagement.md
+++ b/outputs/reporting_app/descriptions/national_engagement.md
@@ -1,0 +1,32 @@
+## National engagement progress chart
+
+This chart provides a clear, month-by-month view of **how engagement within the national target cohort is evolving over time**. It brings together cohort size, engaged population and key milestones to help you quickly understand progress, momentum and areas that may need attention.
+
+### What the chart shows
+
+- **Cohort size over time**
+  The blue line represents the total number of people included in the national cohort each month. This helps you understand whether the underlying population is stable, growing or changing.
+
+- **Engaged population**
+  The yellow line and shaded area show how many people from the cohort were actively engaged each month. This highlights both the scale and the pace of engagement activity.
+
+- **Engagement rate**
+  Hovering over a point reveals the proportion of the cohort that is engaged, giving a more intuitive sense of progress than raw numbers alone.
+
+- **Milestones**
+  The chart automatically identifies and labels important moments in the engagement journey, such as:
+  - When engagement exceeds key thresholds (e.g., 10%, 20%, 50%)
+  - When the engaged population passes major numeric milestones
+  - When a high proportion of Places are actively engaging
+  These annotations help draw attention to meaningful changes without requiring manual interpretation.
+
+- **Interactive hover details**
+  Hovering over any month reveals a concise summary including cohort size, engaged population, engagement rate and Place-level engagement.
+
+### Why this view is useful
+- Provides a clear narrative of how engagement is progressing nationally
+- Highlights key turning points and milestones, helping you spot important changes quickly
+- Helps distinguish between changes driven by cohort size and those driven by engagement activity
+- Supports deeper interpretation of Place-level or demographic-level views by showing the national context
+- Offers an intuitive, visual way to track whether engagement efforts are accelerating, stabilising or slowing over time.
+

--- a/outputs/reporting_app/descriptions/national_overview.md
+++ b/outputs/reporting_app/descriptions/national_overview.md
@@ -1,0 +1,37 @@
+## National overview table
+
+This table provides a **national-level overview of key metrics** for the latest reporting month alongside comparisons with the previous month and longer-term patterns. It brings together monthly averages, short-term changes, indicators of variation across Places and a trendline showing how each metric has evolved over time.
+
+### How national averages are calculated
+National averages are created by summing the values from all Places and dividing by the total relevant population, so each Place contributes proportionally to the overall figure. This produces a single national value that reflects the combined activity across all Places.
+
+### What the table shows
+
+- **Metric name**
+  A descriptive label for each metric.
+
+- **This month's value**
+  The national average for the most recent reporting month.
+
+- **Last month's value**
+  The national average for the previous month, shown alongside the current value for context.
+
+- **Month-to-month difference**
+  A simple comparison between the latest and previous month, displayed with a directional arrow.
+  This highlights short-term movement without implying whether an increase or decrease is positive or negative - interpretation depends on the metric and wider context.
+
+- **Outside-limit rate**
+  The proportion of Places whose observed values fall outside the 95% statistical limits in the funnel plot for the latest month.
+  This is not a performance measure; it simply summarises how much variation exists across Places for that metric.
+  A higher or lower proportion does not imply better or worse performance - it reflects the diversity of local populations, service models and data patterns.
+
+- **Trendline**
+  A small sparkline showing how the national average has changed over time.
+  This provides a quick sense of the longer-term pattern without focusing on individual data points.
+
+### Why this view is useful
+- Brings together current, recent and longer-term national information in one place.
+- Helps identify patterns of variation across Places without making value judgements.
+- Supports exploration of how national averages relate to the diversity of local contexts.
+- Provides a consistent, easy-to-read summary of national-level trends for all metrics.
+

--- a/outputs/reporting_app/descriptions/place_engagement.md
+++ b/outputs/reporting_app/descriptions/place_engagement.md
@@ -1,0 +1,24 @@
+## Place-level engagement table
+
+This table summarises engagement activity at the **Place** level, showing how participation changes over time and how it relates to the size of each cohort.
+
+### What the table shows
+
+- **One row per Place**
+  Each row represents a single Place, with engagement metrics displayed across multiple months.
+
+- **Cohort size**
+  A column indicating how many people are included in the cohort for that place. This figure is the most recent estimate of the number of patients in the target cohort.
+
+- **Monthly engagement counts**
+  The month columns show the number of engaged individuals for that place in each month. This figure is taken from metric "P1" for each month.
+
+- **Engagement rate**
+  A percentage summarising overall engagement relative to cohort size, formatted to one decimal place. This figure is calculated using the most recent engagement count, where missing engagement values are treated as 0.
+
+### Why this view is useful
+- Helps to identify patterns of engagement over time within each Place.
+- Makes it easy to compare relative performance across Places.
+- Highlights Places with high or low engagement rates.
+- Supports operational decisions by showing both absolute engagement counts and cohort-adjusted rates.
+

--- a/outputs/reporting_app/descriptions/place_funnel.md
+++ b/outputs/reporting_app/descriptions/place_funnel.md
@@ -1,0 +1,62 @@
+## Funnel plot
+
+This funnel plot shows how each place's **observed rate per 1,000 population** compares with the expected national rate for the selected metric and month. It provides a way to understand patterns of variation while recognising that Places differ in size, population characteristics and local context.
+
+### What the plot shows
+- **One point per Place**
+  Each marker represents a Place's observed rate for the selected metric in the selected month.
+
+- **National benchmark**
+  A central horizontal line shows the overall national rate, calculated by pooling all Places' counts and denominators.
+
+- **95% and 99% control limits**
+  Curved "funnels" around the central line show the range of values that might reasonably be expected due to *random variation*, given each Place's population size:
+
+  - **Inner funnel**: 95% limits (Poisson-based)
+
+  - **Outer funnel**: 99% limits (Poisson-based)
+
+    These limits naturally widen for smaller populations, where greater variability is expected.
+  
+  - **Highlighted selected Place**
+    The Place chosen in the dashboard is shown with a yellow marker, helping you to see how it sits within the wider pattern.
+
+  - **Colour-coded categories**
+    Points are grouped according to whether their observed rate falls:
+
+    - within the 95% limits
+
+    - between the 95% and 99% limits
+
+    - beyond the 99% limits
+
+    - or represents a Place not currently engaged with their target cohort
+
+      These categories are descriptive rather than evaluative - they simply indicate how each point relates to the statistical limits.
+  
+  - **Interactive hover text**
+    Hovering over a point shows the underlying counts, population size, rater per 1000 and engagement status.
+
+### How to interpret the plot
+
+- **Variation is expected**
+  Places differ in population size, demographics, service models and local circumstances. The funnel plot helps distinguish variation that is expected from the variation that is less likely to be due to chance alone.
+
+- **Points inside the 95% funnel**
+  These fall within the range of variation commonly seen when populations differ in size.
+
+- **Points between the 95% and 99% limits**
+  These are less common but still compatible with expected variation.
+
+- **Points outside the 99% limits**
+  These are statistically unusual relative to the overall rate. This does not imply positive or negative performance - it simply indicates that the observed rate is less likely to be explained by chance alone and may reflect local context, population needs, service configuration or data patterns.
+
+- **Population size matters**
+  Smaller Places naturally show more variability, which is why the funnels are wider at the left of the plot. Larger Places have narrower expected ranges.
+
+### Why this visualisation is useful
+- Helps understand **patterns of variation** across Places of different sizes.
+- Supports interpretation without making value judgements.
+- Highlights where observed rates differ from what might be expected by chance
+- Encourages exploration of local context, population characteristics and service models
+- Provides a clear, interactive way to view variation for metrics over time.

--- a/outputs/reporting_app/descriptions/place_overview.md
+++ b/outputs/reporting_app/descriptions/place_overview.md
@@ -1,0 +1,35 @@
+## Overview table
+
+This table provides a compact **overview of key metrics** for the selected Place, bringing together the most recent month's values, comparison with the previous month, longer-term averages and a small trendline showing how each metric has changed over time.
+
+### What the table shows
+
+- **Metric name**
+  A descriptive label for each metric included in the overview.
+
+- **Latest month's value**
+  The rate per 1,000 for the most recent reporting month.
+
+- **Previous month's value**
+  The rate per 1,000 from the month before, shown alongside the current value for context.
+
+- **Month-on-month difference**
+  A simple comparison between the latest and previous month, displayed with a directional arrow.
+  This highlights short-term movement without implying whether an increase or decrease is positive or negative - interpretation depends on the metric and local context.
+
+- **Long-term average**
+  The average value for the metric across all available months for the selected Place.
+
+- **Difference from average**
+  A comparison between the latest month and the long-term average.
+  This helps to show whether the most recent value is broadly in line with longer-term patterns or represents a departure from them.
+
+- **Sparkline trendline**
+  A small visual showing how the metric has changed over time. Points represent the lowest and highest values. Sparklines are designed to give a quick sense of the overall pattern without focusing on individual data points.
+
+### Why this view is useful
+
+- Brings together current, recent and long-term information in one place.
+- Helps identify patterns of variation over time for each metric.
+- Supports exploration of local context without making value judgements about increases, decreases or differences.
+- Provides a consistent, easy-to-read summary for all metrics relevant to the selected Place.

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -224,8 +224,12 @@ server <- function(input, output, session) {
   )
 
   ## engagement table ---------------------------------------------------------
-  output$engagement_table <- reactable::renderReactable({
-    req(df())
-    display_engagement_table(df = df())
-  })
+  # module server call
+  mod_place_engagement_server(
+    id = "place_engagement",
+    df = shiny::reactive({
+      req(df())
+      df()
+    })
+  )
 }

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -228,4 +228,10 @@ server <- function(input, output, session) {
       month_selected = input$selected_month |> zoo::as.yearmon()
     )
   })
+
+  ## engagement table ---------------------------------------------------------
+  output$engagement_table <- reactable::renderReactable({
+    req(df())
+    display_engagement_table(df = df())
+  })
 }

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -170,27 +170,35 @@ server <- function(input, output, session) {
   })
 
   ## place dashboard ----------------------------------------------------------
+  # card header text
   output$place_header <- shiny::renderText({
     req(input$selected_place)
     input$selected_place
   })
 
-  output$place_table <- reactable::renderReactable({
-    req(
-      df(),
-      input$selected_place,
-      filtered_month_current(),
+  # module server call
+  mod_place_overview_server(
+    id = "place_overview",
+    df = shiny::reactive({
+      req(df())
+      df()
+    }),
+    place = shiny::reactive({
+      req(input$selected_place)
+      input$selected_place
+    }),
+    month_current = shiny::reactive({
+      req(filtered_month_current())
+      filtered_month_current()
+    }),
+    month_previous = shiny::reactive({
+      req(filtered_month_previous())
       filtered_month_previous()
-    )
-    display_dashboard(
-      df = df(),
-      place_selected = input$selected_place,
-      month_latest = filtered_month_current(),
-      month_prev = filtered_month_previous()
-    )
-  })
+    })
+  )
 
   ## place funnel -------------------------------------------------------------
+  # module server call
   mod_place_funnel_server(
     id = "place_funnel",
     df = shiny::reactive({

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -145,15 +145,31 @@ server <- function(input, output, session) {
 
   # outputs -------------------------------------------------------------------
   ## national dashboard -------------------------------------------------------
-  output$national_table <- reactable::renderReactable({
-    req(df(), filtered_month_current(), filtered_month_previous())
+  # output$national_table <- reactable::renderReactable({
+  #   req(df(), filtered_month_current(), filtered_month_previous())
 
-    display_dashboard_national(
-      df = df(),
-      month_latest = filtered_month_current(),
-      month_prev = filtered_month_previous()
-    )
-  })
+  #   display_dashboard_national(
+  #     df = df(),
+  #     month_latest = filtered_month_current(),
+  #     month_prev = filtered_month_previous()
+  #   )
+  # })
+
+  mod_national_overview_server(
+    id = "national_overview",
+    df = shiny::reactive({
+      shiny::req(df())
+      df()
+    }),
+    month_current = shiny::reactive({
+      shiny::req(filtered_month_current())
+      filtered_month_current()
+    }),
+    month_previous = shiny::reactive({
+      shiny::req(filtered_month_previous())
+      filtered_month_previous()
+    })
+  )
 
   ## national data coverage ---------------------------------------------------
   mod_national_coverage_server(

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -191,43 +191,29 @@ server <- function(input, output, session) {
   })
 
   ## place funnel -------------------------------------------------------------
-  # cache funnel data for month:metric for improved UX ---
-  df_funnel <- shiny::reactive({
-    req(df_selected_month(), input$selected_month, input$selected_metric)
-
-    get_data_for_funnel_plot(
-      df = df_selected_month(),
-      month_selected = input$selected_month |> zoo::as.yearmon(),
-      metric_selected = input$selected_metric
-    )
-  }) |>
-    shiny::bindCache(df_version(), input$selected_month, input$selected_metric)
-
-  # cache limits data for month:metric for improved UX ---
-  df_limits <- shiny::reactive({
-    req(df_funnel())
-
-    compute_funnel_limits(df_funnel = df_funnel())
-  }) |>
-    shiny::bindCache(df_version(), input$selected_month, input$selected_metric)
-
-  # render the funnel ---
-  output$place_funnel <- plotly::renderPlotly({
-    req(
-      df_selected_month(),
-      df_funnel(),
-      input$selected_place,
+  mod_place_funnel_server(
+    id = "place_funnel",
+    df = shiny::reactive({
+      req(df_selected_month())
+      df_selected_month()
+    }),
+    place = shiny::reactive({
+      req(input$selected_place)
+      input$selected_place
+    }),
+    metric = shiny::reactive({
+      req(input$selected_metric)
       input$selected_metric
-    )
-
-    get_funnel_plot(
-      df_funnel = df_funnel(),
-      df_limits = df_limits(),
-      place_selected = input$selected_place,
-      metric_selected = input$selected_metric,
-      month_selected = input$selected_month |> zoo::as.yearmon()
-    )
-  })
+    }),
+    month = shiny::reactive({
+      req(input$selected_month)
+      input$selected_month |> zoo::as.yearmon()
+    }),
+    df_version = shiny::reactive({
+      req(df_version)
+      df_version
+    })
+  )
 
   ## engagement table ---------------------------------------------------------
   output$engagement_table <- reactable::renderReactable({

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -156,17 +156,19 @@ server <- function(input, output, session) {
   })
 
   ## national data coverage ---------------------------------------------------
-  output$national_data_coverage_table <- reactable::renderReactable({
-    req(df())
-
-    display_national_data_coverage_table(df = df())
-  })
+  mod_national_coverage_server(
+    id = "national_coverage",
+    df = shiny::reactive({
+      shiny::req(df())
+      df()
+    })
+  )
 
   ## national issues log ------------------------------------------------------
   mod_national_changelog_server(
     id = "national_changelog",
     df_issues = shiny::reactive({
-      req(df_issues())
+      shiny::req(df_issues())
       df_issues()
     })
   )
@@ -174,7 +176,7 @@ server <- function(input, output, session) {
   ## place dashboard ----------------------------------------------------------
   # card header text
   output$place_header <- shiny::renderText({
-    req(input$selected_place)
+    shiny::req(input$selected_place)
     input$selected_place
   })
 
@@ -182,19 +184,19 @@ server <- function(input, output, session) {
   mod_place_overview_server(
     id = "place_overview",
     df = shiny::reactive({
-      req(df())
+      shiny::req(df())
       df()
     }),
     place = shiny::reactive({
-      req(input$selected_place)
+      shiny::req(input$selected_place)
       input$selected_place
     }),
     month_current = shiny::reactive({
-      req(filtered_month_current())
+      shiny::req(filtered_month_current())
       filtered_month_current()
     }),
     month_previous = shiny::reactive({
-      req(filtered_month_previous())
+      shiny::req(filtered_month_previous())
       filtered_month_previous()
     })
   )

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -165,6 +165,12 @@ server <- function(input, output, session) {
     month_previous = filtered_month_previous
   )
 
+  ## national engagement plot -------------------------------------------------
+  mod_national_engagement_server(
+    id = "national_engagement",
+    df = df
+  )
+
   ## national data coverage ---------------------------------------------------
   mod_national_coverage_server(
     id = "national_coverage",

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -163,11 +163,13 @@ server <- function(input, output, session) {
   })
 
   ## national issues log ------------------------------------------------------
-  output$changelog_table <- reactable::renderReactable({
-    req(df_issues())
-
-    display_issueslog(df_issues = df_issues())
-  })
+  mod_national_changelog_server(
+    id = "national_changelog",
+    df_issues = shiny::reactive({
+      req(df_issues())
+      df_issues()
+    })
+  )
 
   ## place dashboard ----------------------------------------------------------
   # card header text

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -8,8 +8,13 @@ server <- function(input, output, session) {
   )
 
   # read the pin version for use as a cache key
-  df_version <- shiny::reactive(
+  pin_version <- shiny::reactive(
     pins::pin_meta(board = board, name = pin_name)$version
+  )
+
+  # read the pin created date (for the version)
+  pin_time <- shiny::reactive(
+    pins::pin_meta(board = board, name = pin_name)$created
   )
 
   # read the pin for issues / changelog
@@ -42,8 +47,6 @@ server <- function(input, output, session) {
 
   metrics <- shiny::reactive({
     req(df())
-
-    # df()$metric |> unique() |> factor()
     df() |>
       dplyr::filter_out(metric_block == 15) |>
       dplyr::distinct(metric) |>
@@ -113,6 +116,16 @@ server <- function(input, output, session) {
   })
 
   # update ui inputs ----------------------------------------------------------
+  # update the data refresh time
+  mod_utils_last_updated_server(
+    id = "national",
+    time = pin_time
+  )
+  mod_utils_last_updated_server(
+    id = "place",
+    time = pin_time
+  )
+
   # update the available places
   shiny::observe({
     shiny::updateSelectizeInput(
@@ -145,48 +158,23 @@ server <- function(input, output, session) {
 
   # outputs -------------------------------------------------------------------
   ## national dashboard -------------------------------------------------------
-  # output$national_table <- reactable::renderReactable({
-  #   req(df(), filtered_month_current(), filtered_month_previous())
-
-  #   display_dashboard_national(
-  #     df = df(),
-  #     month_latest = filtered_month_current(),
-  #     month_prev = filtered_month_previous()
-  #   )
-  # })
-
   mod_national_overview_server(
     id = "national_overview",
-    df = shiny::reactive({
-      shiny::req(df())
-      df()
-    }),
-    month_current = shiny::reactive({
-      shiny::req(filtered_month_current())
-      filtered_month_current()
-    }),
-    month_previous = shiny::reactive({
-      shiny::req(filtered_month_previous())
-      filtered_month_previous()
-    })
+    df = df,
+    month_current = filtered_month_current,
+    month_previous = filtered_month_previous
   )
 
   ## national data coverage ---------------------------------------------------
   mod_national_coverage_server(
     id = "national_coverage",
-    df = shiny::reactive({
-      shiny::req(df())
-      df()
-    })
+    df = df
   )
 
   ## national issues log ------------------------------------------------------
   mod_national_changelog_server(
     id = "national_changelog",
-    df_issues = shiny::reactive({
-      shiny::req(df_issues())
-      df_issues()
-    })
+    df_issues = df_issues
   )
 
   ## place dashboard ----------------------------------------------------------
@@ -199,32 +187,20 @@ server <- function(input, output, session) {
   # module server call
   mod_place_overview_server(
     id = "place_overview",
-    df = shiny::reactive({
-      shiny::req(df())
-      df()
-    }),
+    df = df,
     place = shiny::reactive({
       shiny::req(input$selected_place)
       input$selected_place
     }),
-    month_current = shiny::reactive({
-      shiny::req(filtered_month_current())
-      filtered_month_current()
-    }),
-    month_previous = shiny::reactive({
-      shiny::req(filtered_month_previous())
-      filtered_month_previous()
-    })
+    month_current = filtered_month_current,
+    month_previous = filtered_month_previous
   )
 
   ## place funnel -------------------------------------------------------------
   # module server call
   mod_place_funnel_server(
     id = "place_funnel",
-    df = shiny::reactive({
-      req(df_selected_month())
-      df_selected_month()
-    }),
+    df = df_selected_month,
     place = shiny::reactive({
       req(input$selected_place)
       input$selected_place
@@ -238,8 +214,8 @@ server <- function(input, output, session) {
       input$selected_month |> zoo::as.yearmon()
     }),
     df_version = shiny::reactive({
-      req(df_version)
-      df_version
+      req(pin_version)
+      pin_version
     })
   )
 
@@ -247,9 +223,6 @@ server <- function(input, output, session) {
   # module server call
   mod_place_engagement_server(
     id = "place_engagement",
-    df = shiny::reactive({
-      req(df())
-      df()
-    })
+    df = df
   )
 }

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -52,21 +52,9 @@ ui <- function(request) {
               )
             )
           ),
-          bslib::nav_panel(
-            title = "Data coverage",
-            icon = bsicons::bs_icon("ui-checks-grid"),
-            bslib::layout_sidebar(
-              fillable = TRUE,
-              sidebar = bslib::sidebar(
-                open = FALSE,
-                shiny::includeMarkdown("descriptions/national_coverage.md")
-              ),
-              bslib::card_body(
-                reactable::reactableOutput("national_data_coverage_table"),
-                fill = TRUE
-              )
-            )
-          ),
+
+          # data coverage table
+          mod_national_coverage_ui("national_coverage"),
 
           # change / issues table
           mod_national_changelog_ui("national_changelog")

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -159,21 +159,23 @@ ui <- function(request) {
             # funnel plot ----
             mod_place_funnel_ui("place_funnel"),
 
-            bslib::nav_panel(
-              title = "Engagement",
-              icon = bsicons::bs_icon("table"),
-              bslib::layout_sidebar(
-                fillable = TRUE,
-                open = FALSE,
-                sidebar = bslib::sidebar(
-                  open = FALSE,
-                  shiny::includeMarkdown("descriptions/place_engagement.md")
-                ),
-                bslib::card_body(
-                  reactable::reactableOutput("engagement_table")
-                )
-              )
-            )
+            # engagement table ----
+            mod_place_engagement_ui("place_engagement")
+            # bslib::nav_panel(
+            #   title = "Engagement",
+            #   icon = bsicons::bs_icon("table"),
+            #   bslib::layout_sidebar(
+            #     fillable = TRUE,
+            #     open = FALSE,
+            #     sidebar = bslib::sidebar(
+            #       open = FALSE,
+            #       shiny::includeMarkdown("descriptions/place_engagement.md")
+            #     ),
+            #     bslib::card_body(
+            #       reactable::reactableOutput("engagement_table")
+            #     )
+            #   )
+            # )
           )
         )
       )

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -55,9 +55,6 @@ ui <- function(request) {
           bslib::nav_panel(
             title = "Data coverage",
             icon = bsicons::bs_icon("ui-checks-grid"),
-            # bslib::card_body(reactable::reactableOutput(
-            #   "national_data_coverage_table"
-            # ))
             bslib::layout_sidebar(
               fillable = TRUE,
               sidebar = bslib::sidebar(
@@ -70,22 +67,9 @@ ui <- function(request) {
               )
             )
           ),
-          bslib::nav_panel(
-            title = "Change log",
-            icon = bsicons::bs_icon("journal-text"),
-            # bslib::card_body(reactable::reactableOutput("changelog_table"))
-            bslib::layout_sidebar(
-              fillable = TRUE,
-              sidebar = bslib::sidebar(
-                open = FALSE,
-                shiny::includeMarkdown("descriptions/national_changelog.md")
-              ),
-              bslib::card_body(
-                reactable::reactableOutput("changelog_table"),
-                fill = TRUE
-              )
-            )
-          )
+
+          # change / issues table
+          mod_national_changelog_ui("national_changelog")
         )
       )
     ),
@@ -161,21 +145,6 @@ ui <- function(request) {
 
             # engagement table ----
             mod_place_engagement_ui("place_engagement")
-            # bslib::nav_panel(
-            #   title = "Engagement",
-            #   icon = bsicons::bs_icon("table"),
-            #   bslib::layout_sidebar(
-            #     fillable = TRUE,
-            #     open = FALSE,
-            #     sidebar = bslib::sidebar(
-            #       open = FALSE,
-            #       shiny::includeMarkdown("descriptions/place_engagement.md")
-            #     ),
-            #     bslib::card_body(
-            #       reactable::reactableOutput("engagement_table")
-            #     )
-            #   )
-            # )
           )
         )
       )

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -169,26 +169,8 @@ ui <- function(request) {
               )
             ),
 
-            bslib::nav_panel(
-              title = "Funnel plot",
-              icon = bsicons::bs_icon("funnel"),
-              bslib::layout_sidebar(
-                fillable = TRUE,
-                sidebar = bslib::sidebar(
-                  open = FALSE,
-                  shiny::includeMarkdown("descriptions/place_funnel.md")
-                ),
-                bslib::card_body(
-                  plotly::plotlyOutput(
-                    "place_funnel",
-                    height = "100%",
-                    fill = TRUE
-                  ),
-                  fill = TRUE,
-                  height = "100%"
-                )
-              )
-            ),
+            # funnel plot ----
+            mod_place_funnel_ui("place_funnel"),
 
             bslib::nav_panel(
               title = "Engagement",

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -40,19 +40,51 @@ ui <- function(request) {
           bslib::nav_panel(
             title = "Overview",
             icon = bsicons::bs_icon("table"),
-            bslib::card_body(reactable::reactableOutput("national_table"))
+            bslib::layout_sidebar(
+              fillable = TRUE,
+              sidebar = bslib::sidebar(
+                open = FALSE,
+                shiny::includeMarkdown("descriptions/national_overview.md")
+              ),
+              bslib::card_body(
+                reactable::reactableOutput("national_table"),
+                fill = TRUE
+              )
+            )
           ),
           bslib::nav_panel(
             title = "Data coverage",
             icon = bsicons::bs_icon("ui-checks-grid"),
-            bslib::card_body(reactable::reactableOutput(
-              "national_data_coverage_table"
-            ))
+            # bslib::card_body(reactable::reactableOutput(
+            #   "national_data_coverage_table"
+            # ))
+            bslib::layout_sidebar(
+              fillable = TRUE,
+              sidebar = bslib::sidebar(
+                open = FALSE,
+                shiny::includeMarkdown("descriptions/national_coverage.md")
+              ),
+              bslib::card_body(
+                reactable::reactableOutput("national_data_coverage_table"),
+                fill = TRUE
+              )
+            )
           ),
           bslib::nav_panel(
             title = "Change log",
             icon = bsicons::bs_icon("journal-text"),
-            bslib::card_body(reactable::reactableOutput("changelog_table"))
+            # bslib::card_body(reactable::reactableOutput("changelog_table"))
+            bslib::layout_sidebar(
+              fillable = TRUE,
+              sidebar = bslib::sidebar(
+                open = FALSE,
+                shiny::includeMarkdown("descriptions/national_changelog.md")
+              ),
+              bslib::card_body(
+                reactable::reactableOutput("changelog_table"),
+                fill = TRUE
+              )
+            )
           )
         )
       )
@@ -122,25 +154,55 @@ ui <- function(request) {
             full_screen = TRUE,
 
             bslib::nav_panel(
-              title = "Dashboard table",
+              title = "Overview",
               icon = bsicons::bs_icon("table"),
-              bslib::card_body(
-                reactable::reactableOutput("place_table"),
-                fill = TRUE
+              bslib::layout_sidebar(
+                fillable = TRUE,
+                sidebar = bslib::sidebar(
+                  open = FALSE,
+                  shiny::includeMarkdown("descriptions/place_overview.md")
+                ),
+                bslib::card_body(
+                  reactable::reactableOutput("place_table"),
+                  fill = TRUE
+                )
               )
             ),
 
             bslib::nav_panel(
               title = "Funnel plot",
               icon = bsicons::bs_icon("funnel"),
-              bslib::card_body(
-                plotly::plotlyOutput(
-                  "place_funnel",
-                  height = "100%",
-                  fill = TRUE
+              bslib::layout_sidebar(
+                fillable = TRUE,
+                sidebar = bslib::sidebar(
+                  open = FALSE,
+                  shiny::includeMarkdown("descriptions/place_funnel.md")
                 ),
-                fill = TRUE,
-                height = "100%"
+                bslib::card_body(
+                  plotly::plotlyOutput(
+                    "place_funnel",
+                    height = "100%",
+                    fill = TRUE
+                  ),
+                  fill = TRUE,
+                  height = "100%"
+                )
+              )
+            ),
+
+            bslib::nav_panel(
+              title = "Engagement",
+              icon = bsicons::bs_icon("table"),
+              bslib::layout_sidebar(
+                fillable = TRUE,
+                open = FALSE,
+                sidebar = bslib::sidebar(
+                  open = FALSE,
+                  shiny::includeMarkdown("descriptions/place_engagement.md")
+                ),
+                bslib::card_body(
+                  reactable::reactableOutput("engagement_table")
+                )
               )
             )
           )

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -37,21 +37,24 @@ ui <- function(request) {
         # main ----
         bslib::navset_card_tab(
           id = "national_tabs",
-          bslib::nav_panel(
-            title = "Overview",
-            icon = bsicons::bs_icon("table"),
-            bslib::layout_sidebar(
-              fillable = TRUE,
-              sidebar = bslib::sidebar(
-                open = FALSE,
-                shiny::includeMarkdown("descriptions/national_overview.md")
-              ),
-              bslib::card_body(
-                reactable::reactableOutput("national_table"),
-                fill = TRUE
-              )
-            )
-          ),
+          # bslib::nav_panel(
+          #   title = "Overview",
+          #   icon = bsicons::bs_icon("table"),
+          #   bslib::layout_sidebar(
+          #     fillable = TRUE,
+          #     sidebar = bslib::sidebar(
+          #       open = FALSE,
+          #       shiny::includeMarkdown("descriptions/national_overview.md")
+          #     ),
+          #     bslib::card_body(
+          #       reactable::reactableOutput("national_table"),
+          #       fill = TRUE
+          #     )
+          #   )
+          # ),
+
+          # overview metrics
+          mod_national_overview_ui("national_overview"),
 
           # data coverage table
           mod_national_coverage_ui("national_coverage"),

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -153,21 +153,8 @@ ui <- function(request) {
             id = "place_tabs",
             full_screen = TRUE,
 
-            bslib::nav_panel(
-              title = "Overview",
-              icon = bsicons::bs_icon("table"),
-              bslib::layout_sidebar(
-                fillable = TRUE,
-                sidebar = bslib::sidebar(
-                  open = FALSE,
-                  shiny::includeMarkdown("descriptions/place_overview.md")
-                ),
-                bslib::card_body(
-                  reactable::reactableOutput("place_table"),
-                  fill = TRUE
-                )
-              )
-            ),
+            # overview table ----
+            mod_place_overview_ui("place_overview"),
 
             # funnel plot ----
             mod_place_funnel_ui("place_funnel"),

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -23,8 +23,13 @@ ui <- function(request) {
         # sidebar ----
         sidebar = bslib::sidebar(
           shiny::div(
-            # add some branding
+            # separator line
             shiny::hr(),
+
+            # show when the data was last updated
+            mod_utils_last_updated_ui("national"),
+
+            # SU logo
             shiny::tags$div(
               style = "text-align:center; padding: 10px 0;",
               shiny::tags$img(
@@ -37,21 +42,6 @@ ui <- function(request) {
         # main ----
         bslib::navset_card_tab(
           id = "national_tabs",
-          # bslib::nav_panel(
-          #   title = "Overview",
-          #   icon = bsicons::bs_icon("table"),
-          #   bslib::layout_sidebar(
-          #     fillable = TRUE,
-          #     sidebar = bslib::sidebar(
-          #       open = FALSE,
-          #       shiny::includeMarkdown("descriptions/national_overview.md")
-          #     ),
-          #     bslib::card_body(
-          #       reactable::reactableOutput("national_table"),
-          #       fill = TRUE
-          #     )
-          #   )
-          # ),
 
           # overview metrics
           mod_national_overview_ui("national_overview"),
@@ -104,11 +94,14 @@ ui <- function(request) {
               )
             ),
 
+            # bookmark button
+            shiny::bookmarkButton(label = "Bookmark", width = "100%"),
+
             # divider
             shiny::hr(),
 
-            # bookmark button
-            shiny::bookmarkButton(label = "Bookmark"),
+            # show when the data was last updated
+            mod_utils_last_updated_ui("place"),
 
             # add some branding
             shiny::tags$div(

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -46,6 +46,9 @@ ui <- function(request) {
           # overview metrics
           mod_national_overview_ui("national_overview"),
 
+          # engagemet plot
+          mod_national_engagement_ui("national_engagement"),
+
           # data coverage table
           mod_national_coverage_ui("national_coverage"),
 


### PR DESCRIPTION
closes #25 

This PR delivers a substantial set of improvements across the natonal and place-level dashboard views. It introduces new modules, enhances existing UI / Server structure, adds a new national engagement visualisation and provides clearer contexual information to users through markdown descriptions and data-age indicators.

## Summary of changes
### 1. New national engagement visualisation
Added two new functions:
- `get_data_for_national_engagement()` - prepares monthly cohort and engagement summaries
- `display_national_engagement_plot()` - generates a {plotly} visual showing engagement progress and milestone annotations

Introduced a new module: `mod_national_engagement.R`, encapsulating UI and server logic for the engagement chart:
- Added calls to this module within the main UI and server files
- Added a markdown description to accompany the visualisation

#### Screenshot (synthetic data)
<img width="3200" height="1800" alt="Screen Shot 2026-04-23 at 19 13 26" src="https://github.com/user-attachments/assets/c2c2e66f-6535-4ed2-a0c4-82113d885889" />

With ony one real data point available so far (Jan 2026), the live visualisation does not yet show meaningful trends. The screenshot above, created using synthetic data, demonstrates what the chart will look like once more months are available. It highlights the key features:
- Cohort size (blue line): shows the total number of people included in the national cohort each month
- Engaged population (yellow line and shaded area): shows how many people from the cohort were actively engaged each month
- Rich hover text: provides additional context for each month, including engagement rate and population counts
- Automatic milestone annotations: key moments - such as engagement thresholds or changes in growth - are highlighted directly on the chart.

### 2. Displaying when data was last refreshed
- Added a new utility module: `mod_utils_last_updated.R`, containing UI and server logic for showing the age of the underlying aggregate dataset.
- Introduced a reactive `pin_time` to read the timestamp of the aggregate data pin
- Renamed `df_version` to `pin_version` for clarity
- Removed unecessary `reactive()` wrappers around module parameters
- Added UI calls to dispaly the "last refreshed" message in both national and place sidebars
- Minor housekeeping and removal of redundant code

### 3. Modularisation of national-level and place-level views
Refactored several national components into standalone modules:
- `mod_national_overview.R` - national overview table
- `mod_national_coverage.R` - national data coverage table
- `mod_national_changelog.R` - national change / issues log

Refactored several place-level components:
- `mod_place_overview.R` - place overview table
- `mod_place_engagement.R` - place engagement table
- `mod_place_funnel.R` - funnel plot visualisation

These changes continue to the move toward a fully modularised dashboard architecture.

### 4. Enhancements to place-level engagement
- Added support for the place-level engagement table in `server.R`
- Added two helper functions:
  - `get_data_for_engagement_table()`
  - `display_engagement_table()`

### 5. UI improvements and markdown descriptions
- Introduced `bslib::layout_sidebar()` for all dashboard views, enabling sidebar-based markdown descriptions.
- Added markdown files describing each visualisation
- Updated UI to position the bookmark button more logically within the Place navigation panel

#### Screenshot
<img width="1360" height="896" alt="image" src="https://github.com/user-attachments/assets/9dc3f354-4e9f-4b19-8a7b-6230f1f298ca" />
