### PR TITLE
Add ability to preview draft / test data in the shiny app

### DIFF
--- a/R/01_prepare_app_data.R
+++ b/R/01_prepare_app_data.R
@@ -19,6 +19,9 @@ validation <- validate_monthly_submissions()
 validation$issues |> View()
 validation$data |> View()
 
+# see how the validated data look in the app
+launch_app_with_test_data()
+
 # --- Process data ------------------------------------------------------------
 
 # when ready to update the data, run this:

--- a/R/data_ingest.R
+++ b/R/data_ingest.R
@@ -1342,3 +1342,34 @@ check_metric_alignment <- function(df) {
       )
   }
 }
+
+#' Launch the reporting app using test data
+#'
+#' @description
+#' Sets the global option `use_test_data = TRUE` and launches the Shiny
+#' reporting application. This is intended as a tool for the validation of
+#' ingested data to ensure the ingested data does not break any app
+#' functionality.
+#'
+#' @details
+#' Calling this function modifies the current R session by setting
+#' `options(use_test_data = TRUE)`. The shiny app recognises this option to
+#' load the dataset from `validation$data` to see how the validated data
+#' appears in the app.
+#'
+#' @returns This function is called for its side effects and returns the
+#' result of `shiny::runApp()`
+#'
+#' @examples
+#' \dontrun{
+#' launch_app_with_test_data()
+#' }
+launch_app_with_test_data <- function() {
+  options(use_test_data = TRUE)
+  shiny::runApp(
+    appDir = here::here("outputs", "reporting_app"),
+    launch.browser = function(url) {
+      browseURL(url)
+    }
+  )
+}

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -1,21 +1,32 @@
 # server ----------------------------------------------------------------------
 server <- function(input, output, session) {
-  # read pin reactively every hour --------------------------------------------
-  df_raw <- pins::pin_reactive_read(
-    board = board,
-    name = pin_name,
-    interval = 60 * 60 * 1000 # check hourly
-  )
+  # decide whether to use local test data or not
+  use_test_data <- getOption(x = "use_test_data", default = FALSE)
 
-  # read the pin version for use as a cache key
-  pin_version <- shiny::reactive(
-    pins::pin_meta(board = board, name = pin_name)$version
-  )
+  # conditionally load the pin or from `validation$data` if testing locally
+  if (use_test_data) {
+    df_raw <- get0("validation", envir = .GlobalEnv, ifnotfound = NULL)$data |>
+      shiny::reactive()
+    pin_version <- 0 |> shiny::reactive()
+    pin_time <- Sys.time() |> shiny::reactive()
+  } else {
+    # read pin reactively every hour --------------------------------------------
+    df_raw <- pins::pin_reactive_read(
+      board = board,
+      name = pin_name,
+      interval = 60 * 60 * 1000 # check hourly
+    )
 
-  # read the pin created date (for the version)
-  pin_time <- shiny::reactive(
-    pins::pin_meta(board = board, name = pin_name)$created
-  )
+    # read the pin version for use as a cache key
+    pin_version <- shiny::reactive(
+      pins::pin_meta(board = board, name = pin_name)$version
+    )
+
+    # read the pin created date (for the version)
+    pin_time <- shiny::reactive(
+      pins::pin_meta(board = board, name = pin_name)$created
+    )
+  }
 
   # read the pin for issues / changelog
   df_issues <- pins::pin_reactive_read(


### PR DESCRIPTION
closes #28 

This pull request introduces a workflow improvements that allows developers to preview the Shiny reporting app using recently validated local data rather than relying solely on data deployed to Posit Connect.

### Summary of changes
- **New helper function**:
  Adds `launch_app_with_test_data()` to `data_ingest.R`. This function:
  - sets a global option `use_test_data = TRUE`
  - launches the local shiny app from `outputs/reporting_app`
  - enables quick inspection of app behaviour using freshly validated data

- **Integration into validation workflow**:
  Updates `01_prepare_app_data.R` to call `launch_app_with_test_data()` as part of the recent submissions validation process, making it easier to check for unexpected values, stability issues or UI regressions before publishing.

- **Shiny app behaviour update**:
  Modifies `server.R` so the app checks `getOption("use_test_data")` to determine whether to:
  - load locally validated data (test mode) or
  - fall back tot he default behaviour of loading data from Posit Connect

## Why this change is useful
This enhancement streamlines the validation workflow by allowing a preview of the app with the exact data just validated. It reduces friction, improves confidence in the data pipeline and helps catch issues earlier in the process.
