### PR TITLE
Ordering fix for change / issues log + ingestion tweaks

### DIFF
--- a/R/data_ingest.R
+++ b/R/data_ingest.R
@@ -227,7 +227,9 @@ get_issues_log <- function(
   tmp <- tempfile()
   chnglg$download(dest = tmp, overwrite = TRUE)
   df <- readxl::read_excel(path = tmp, sheet = sheetname) |>
-    janitor::clean_names()
+    janitor::clean_names() |>
+    # put the newest entries first
+    dplyr::arrange(dplyr::desc(date))
 
   # return the df
   return(df)

--- a/R/data_ingest.R
+++ b/R/data_ingest.R
@@ -866,6 +866,8 @@ collate_submissions_for_month <- function(ms_teams_folder = NULL) {
   # connect to the Teams / SharePoint site
   if (is.null(ms_teams_folder)) {
     folder <- get_ms_teams_folder()
+  } else {
+    folder <- ms_teams_folder
   }
 
   # list folders

--- a/outputs/reporting_app/R/mod_national_changelog.R
+++ b/outputs/reporting_app/R/mod_national_changelog.R
@@ -29,7 +29,9 @@ mod_national_changelog_server <- function(id, df_issues) {
     output$changelog_table <- reactable::renderReactable({
       req(df_issues())
 
-      display_issueslog(df_issues = df_issues())
+      display_issueslog(
+        df_issues = df_issues() |> dplyr::arrange(dplyr::desc(date))
+      )
     })
   })
 }


### PR DESCRIPTION
closes #30 

This PR introduces improvements to the ingestion pipeline and the way change-log entries are displayed in the dashboard.

## Key changes
- Ensures entries in the **Change / issues log** are displayed in decreasing date order, improving readability and making the most recent updates easier to find
- Additional ingestion-related tweaks and cleanup to support February 2026 data processing

## Why this matters
- The change-log ordering fix resolves a usability issues where new entries could appear buried below older ones.
- The ingestion adjustments support smoother processing of the Feburary 2026 submission and align with the ongoing improvements to the data pipeline