### PR TITLE
Enhance navigation usability, add demographic visualisations, improve engagement table and fix multiple reactivity / UI bugs

### DIFF
--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -1383,10 +1383,11 @@ get_data_for_engagement_table <- function(df) {
 #'
 #' @returns A {reactable} widget suitable for display in a Shiny app or R
 #' Markdown dashboard.
-display_engagement_table <- function(df) {
+display_engagement_table <- function(df, place_highlight = NULL) {
   # get the engagement data
   df_engagement <- get_data_for_engagement_table(df = df)
 
+  # produce the table
   df_engagement |>
     reactable::reactable(
       pagination = FALSE,
@@ -1394,6 +1395,16 @@ display_engagement_table <- function(df) {
       resizable = TRUE,
       wrap = FALSE,
       fullWidth = FALSE, # enables horizontal scrolling
+
+      # highlight the row with the selected Place
+      rowStyle = function(index) {
+        row <- df_engagement[index, ]
+        if (!is.null(place_highlight) && row$place == place_highlight) {
+          list(background = "#fff3cd")
+        } else {
+          list()
+        }
+      },
 
       # default column behaviour
       defaultColDef = reactable::colDef(

--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -2006,6 +2006,11 @@ get_data_for_national_engagement <- function(df) {
       value_type == "patients",
       !is.na(value) # need to do this in case a place left all blank
     ) |>
+    # summarise by Place and month
+    dplyr::summarise(
+      .by = c(place, month_zoo),
+      value = median(value, na.rm = TRUE) # taking the median to handle small number of cases where cohort size varies across metrics
+    ) |>
     # summarise
     dplyr::summarise(
       .by = month_zoo,

--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -2222,3 +2222,169 @@ display_national_engagement_plot <- function(df) {
     ) |>
     plotly::config(displaylogo = FALSE)
 }
+
+
+#' Prepare demographic cohort data for plotting
+#'
+#' @description
+#' This function take raw metric-level data and produces a summarised dataset
+#' suitable for demographic split visualisations. It filters to patient counts,
+#' aggregates values at the Place level, then aggregates again to produce
+#' national-level cohort sizes for each demographic group and month.
+#'
+#' The returned data frame includes cohort sizes, proportions, suppression
+#' indicators and pre-built text fields for {plotly} hover labels and bar
+#' labels.
+#'
+#' @param df A data frame containing raw metric data.
+#'
+#' @returns A data frame containing one row per demographic group per month,
+#' with the following key columns:
+#' - `month_zoo` Reporting month
+#' - `month_f` A factor version of the month for animation frames
+#' - `demographic_type` Demographic category
+#' - `demographic_value` Demographic subgroup
+#' - `cohort_size` Total number of patients in the cohort
+#' - `cohort_prop` Proportion of the cohort represented by the subgroup
+#' - `n_places` Number of Places included
+#' - `n_suppressed` Number of Places with suppressed values
+#' - `n_place_contrib` Number of places contributing non-suppressed values
+#' - `hover_text` Formatted HTML text for {plotly} tooltips
+#' - `bar_text` Formatted text for bar labels
+#'
+#' @examples
+#' \dontrun {
+#' df_summary <- get_data_for_demographic_split(df = df)
+#' }
+get_data_for_demographic_split <- function(df) {
+  df_return <-
+    df |>
+    dplyr::filter(
+      value_type == "patients",
+      metric_id != "P1"
+    ) |>
+    # summarise by Place
+    dplyr::summarise(
+      .by = c(
+        place,
+        month_zoo,
+        demographic_type,
+        demographic_value,
+        value_suppressed
+      ),
+      value = median(value, na.rm = TRUE),
+      any_suppressed = any(value_suppressed)
+    ) |>
+    # summarise for the national cohort
+    dplyr::summarise(
+      .by = c(month_zoo, demographic_type, demographic_value),
+      cohort_size = sum(value, na.rm = TRUE),
+      n_places = dplyr::n_distinct(place, na.rm = TRUE),
+      n_suppressed = sum(any_suppressed, na.rm = TRUE),
+      n_place_contrib = n_places - n_suppressed
+    ) |>
+    dplyr::arrange(month_zoo) |>
+    dplyr::mutate(
+      .by = c(demographic_type, month_zoo),
+      # get a chart-friendly month
+      month_f = month_zoo |> as.character() |> forcats::as_factor(),
+      # remove unused factor levels
+      demographic_value = forcats::fct_drop(f = demographic_value),
+      cohort_prop = cohort_size / sum(cohort_size, na.rm = TRUE),
+      # hover text generation
+      hover_cohort = prettyunits::pretty_num(cohort_size),
+      hover_cohort_prop = scales::percent(cohort_prop, accuracy = 0.1),
+      hover_places = dplyr::if_else(
+        condition = n_place_contrib > 1,
+        true = "Places",
+        false = "Place"
+      ),
+      hover_text = glue::glue(
+        "<b>{demographic_value}</b>
+      {hover_cohort} ({hover_cohort_prop})
+      Cohort comprised of {n_places - n_suppressed} {hover_places}"
+      ),
+      bar_text = glue::glue("{hover_cohort} ({hover_cohort_prop})")
+    )
+
+  return(df_return)
+}
+
+
+#' Display a demographic split bar chart
+#'
+#' @description
+#' This function takes a pre-summarised dataset produced by
+#' `get_data_for_demographic_split()` and generates an animated horizontal bar
+#' chart showing cohort sizes by demographic group over time.
+#'
+#' The chart uses {plotly} and includes:
+#' - one frame per month (`month_f`)
+#' - bars representing cohort size
+#' - labels positioned outside the bars
+#' - hover text showing cohort size, proportion and contributing places
+#'
+#' @param df A data frame containing summarised demographic cohort data.
+#' @param selected_demographic A character string specifying which
+#' demographic type to display (e.g., `"Age Group"`, `"Ethnic Group"`,
+#' `"Deprivation Quintile"`). Defaults to `"Age Group"`.
+#'
+#' @returns A {plotly} bar chart object
+#'
+#' @examples
+#' \dontrun{
+#' df_summary <- get_data_for_demographic_split(df)
+#' display_demographic_split_chart(df_summary, "Ethnic Group")
+#' }
+display_demographic_split_chart <- function(
+  df,
+  selected_demographic = "Age Group"
+) {
+  # validate the demographic
+  selected_demographic <- rlang::arg_match(
+    arg = selected_demographic,
+    values = df$demographic_type |> unique() |> as.character()
+  )
+
+  # filter the data for the selected demographic
+  df_plot <-
+    df |>
+    dplyr::filter(demographic_type == selected_demographic) |>
+    dplyr::mutate(
+      demographic_value = demographic_value |>
+        forcats::fct_drop() |> # remove any unused factor levels
+        forcats::fct_rev() |> # put in reverse order for correct order in plot
+        forcats::fct_relevel("Not known", after = 0) # put "Not known" last in the plot
+    )
+
+  # gather some information first
+  max_x <- max(df_plot$cohort_size, na.rm = TRUE)
+
+  # construct the plot
+  p <-
+    df_plot |>
+    plotly::plot_ly(
+      y = ~demographic_value,
+      x = ~cohort_size,
+      frame = ~month_f,
+      type = "bar",
+      text = ~bar_text,
+      textfont = list(color = "black"),
+      textposition = "outside",
+      hovertext = ~hover_text,
+      hoverinfo = "text",
+      color = I("#5881c1")
+    ) |>
+    plotly::animation_slider(currentvalue = list(prefix = "")) |>
+    plotly::layout(
+      title = list(text = glue::glue("{selected_demographic}")),
+      xaxis = list(title = "", range = c(0, max_x * 1.15), automargin = TRUE),
+      yaxis = list(title = ""),
+      font = list(family = "Roboto, Arial, sans-serif", size = 16),
+      margin = list(l = 40, r = 40, t = 100, b = 60)
+    ) |>
+    plotly::config(displaylogo = FALSE)
+
+  # return the plot
+  return(p)
+}

--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -789,8 +789,7 @@ display_dashboard <- function(df, place_selected, month_latest, month_prev) {
             minWidth = 150,
             maxWidth = 1000,
             cell = reactablefmtr::react_sparkline(
-              # data = _,
-              data = ~trendline,
+              data = df_dashboard,
               show_area = TRUE,
               line_color = "#5881c1",
               highlight_points = reactablefmtr::highlight_points(

--- a/outputs/reporting_app/R/mod_national_changelog.R
+++ b/outputs/reporting_app/R/mod_national_changelog.R
@@ -7,8 +7,15 @@ mod_national_changelog_ui <- function(id) {
 
   # define the UI
   bslib::nav_panel(
-    title = "Change log",
-    icon = bsicons::bs_icon("journal-text"),
+    value = "change_log",
+    title = shiny::span(
+      bsicons::bs_icon("journal-text"),
+      "Change log"
+    ) |>
+      bslib::tooltip(
+        "Record of issues, observations and data-ingestion changes to support learning and transparency.",
+        options = list(trigger = "hover")
+      ),
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(

--- a/outputs/reporting_app/R/mod_national_coverage.R
+++ b/outputs/reporting_app/R/mod_national_coverage.R
@@ -7,8 +7,15 @@ mod_national_coverage_ui <- function(id) {
 
   # define the UI
   bslib::nav_panel(
-    title = "Data coverage",
-    icon = bsicons::bs_icon("ui-checks-grid"),
+    value = "data_coverage",
+    title = shiny::span(
+      bsicons::bs_icon("ui-checks-grid"),
+      "Data coverage"
+    ) |>
+      bslib::tooltip(
+        "At-a-glance view of which Places have processed data each month, showing coverage and gaps.",
+        options = list(trigger = "hover")
+      ),
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(

--- a/outputs/reporting_app/R/mod_national_demographics.R
+++ b/outputs/reporting_app/R/mod_national_demographics.R
@@ -1,0 +1,54 @@
+# --- Demographics (National) -------------------------------------------------
+
+# ui ----
+mod_national_demographics_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the ui
+  bslib::nav_panel(
+    title = "Demographics",
+    icon = bsicons::bs_icon("bar-chart"),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      open = FALSE,
+      sidebar = bslib::sidebar(
+        open = FALSE,
+        shiny::includeMarkdown("descriptions/national_demographics.md")
+      ),
+      bslib::card_body(
+        plotly::plotlyOutput(ns("demographics_plot"))
+      )
+    )
+  )
+}
+
+# server ----
+mod_national_demographics_server <- function(
+  id,
+  df,
+  selected_demographic,
+  df_version
+) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # shiny::req(df(), selected_demographic(), df_version())
+
+    # get the data, cached for df_version and demographic
+    plot_data <- shiny::reactive({
+      shiny::req(df(), df_version())
+      get_data_for_demographic_split(df = df())
+    }) |>
+      shiny::bindCache(df_version())
+
+    # update the plot
+    output$demographics_plot <- plotly::renderPlotly({
+      shiny::req(df(), selected_demographic())
+
+      # display the plot
+      display_demographic_split_chart(
+        df = plot_data(),
+        selected_demographic = selected_demographic()
+      )
+    })
+  })
+}

--- a/outputs/reporting_app/R/mod_national_demographics.R
+++ b/outputs/reporting_app/R/mod_national_demographics.R
@@ -7,8 +7,15 @@ mod_national_demographics_ui <- function(id) {
 
   # define the ui
   bslib::nav_panel(
-    title = "Demographics",
-    icon = bsicons::bs_icon("bar-chart"),
+    value = "demographics",
+    title = shiny::span(
+      bsicons::bs_icon("bar-chart"),
+      "Demographics"
+    ) |>
+      bslib::tooltip(
+        "Month-by-month view of how the national cohort is distributed across demographic groups and how those proportions shift over time.",
+        options = list(trigger = "hover")
+      ),
     bslib::layout_sidebar(
       fillable = TRUE,
       open = FALSE,

--- a/outputs/reporting_app/R/mod_national_engagement.R
+++ b/outputs/reporting_app/R/mod_national_engagement.R
@@ -7,8 +7,15 @@ mod_national_engagement_ui <- function(id) {
 
   # define the ui
   bslib::nav_panel(
-    title = "Engagement",
-    icon = bsicons::bs_icon("graph-up"),
+    value = "engagement_national",
+    title = shiny::span(
+      bsicons::bs_icon("graph-up"),
+      "Engagement"
+    ) |>
+      bslib::tooltip(
+        "Month-by-month view of engagement in the national target cohort, highlighting progress, momentum and key milestones.",
+        options = list(trigger = "hover")
+      ),
     bslib::layout_sidebar(
       fillable = TRUE,
       open = FALSE,

--- a/outputs/reporting_app/R/mod_national_overview.R
+++ b/outputs/reporting_app/R/mod_national_overview.R
@@ -7,8 +7,15 @@ mod_national_overview_ui <- function(id) {
 
   # define the ui
   bslib::nav_panel(
-    title = "Overview",
-    icon = bsicons::bs_icon("table"),
+    value = "overview_national",
+    title = shiny::span(
+      bsicons::bs_icon("table"),
+      "Overview"
+    ) |>
+      bslib::tooltip(
+        "National-level snapshot of key monthly metrics, showing short- and long-term changes and variation across Places.",
+        options = list(trigger = "hover")
+      ),
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(

--- a/outputs/reporting_app/R/mod_place_engagement.R
+++ b/outputs/reporting_app/R/mod_place_engagement.R
@@ -7,8 +7,15 @@ mod_place_engagement_ui <- function(id) {
 
   # define the UI
   bslib::nav_panel(
-    title = "Engagement",
-    icon = bsicons::bs_icon("table"),
+    value = "engagement_place",
+    title = shiny::span(
+      bsicons::bs_icon("table"),
+      "Engagement"
+    ) |>
+      bslib::tooltip(
+        "Summary of engagement activity for each Place, showing how participation changes over time relative to cohort size.",
+        options = list(trigger = "hover")
+      ),
     bslib::layout_sidebar(
       fillable = TRUE,
       open = FALSE,

--- a/outputs/reporting_app/R/mod_place_engagement.R
+++ b/outputs/reporting_app/R/mod_place_engagement.R
@@ -24,12 +24,12 @@ mod_place_engagement_ui <- function(id) {
 }
 
 # server ----
-mod_place_engagement_server <- function(id, df) {
+mod_place_engagement_server <- function(id, df, place) {
   shiny::moduleServer(id, function(input, output, session) {
     # update the table
     output$engagement_table <- reactable::renderReactable({
-      req(df())
-      display_engagement_table(df = df())
+      req(df(), place())
+      display_engagement_table(df = df(), place_highlight = place())
     })
   })
 }

--- a/outputs/reporting_app/R/mod_place_funnel.R
+++ b/outputs/reporting_app/R/mod_place_funnel.R
@@ -7,8 +7,15 @@ mod_place_funnel_ui <- function(id) {
 
   # define the UI
   bslib::nav_panel(
-    title = "Funnel plot",
-    icon = bsicons::bs_icon("funnel"),
+    value = "funnel_plot",
+    title = shiny::span(
+      bsicons::bs_icon("funnel"),
+      "Funnel plot"
+    ) |>
+      bslib::tooltip(
+        "Shows how each Place's observed rate compares with the expected national rate, helping you understand variation and whether differences are within expected limits.",
+        options = list(trigger = "hover")
+      ),
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(

--- a/outputs/reporting_app/R/mod_place_overview.R
+++ b/outputs/reporting_app/R/mod_place_overview.R
@@ -7,8 +7,15 @@ mod_place_overview_ui <- function(id) {
 
   # define the UI
   bslib::nav_panel(
-    title = "Overview",
-    icon = bsicons::bs_icon("table"),
+    value = "overview_place",
+    title = shiny::span(
+      bsicons::bs_icon("table"),
+      "Overview"
+    ) |>
+      bslib::tooltip(
+        "Compact summary of key monthly metrics for the selected Place, including recent values, month-to-month change, longer-term averages and a mini trendline.",
+        options = list(trigger = "hover")
+      ),
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(

--- a/outputs/reporting_app/R/mod_utils_last_updated.R
+++ b/outputs/reporting_app/R/mod_utils_last_updated.R
@@ -9,7 +9,11 @@ mod_utils_last_updated_ui <- function(id) {
   bslib::card(
     class = "p-2 text-center",
     uiOutput(ns("pin_last_updated"))
-  )
+  ) |>
+    bslib::tooltip(
+      "Time since the app's underlying data was last refreshed, helping you see how current the figures are.",
+      options = list(trigger = "hover")
+    )
 }
 
 # server ----

--- a/outputs/reporting_app/R/mod_utils_last_updated.R
+++ b/outputs/reporting_app/R/mod_utils_last_updated.R
@@ -15,7 +15,34 @@ mod_utils_last_updated_ui <- function(id) {
 # server ----
 mod_utils_last_updated_server <- function(id, time) {
   shiny::moduleServer(id, function(input, output, session) {
+    # reactive that determines how often to update the UI
+    update_interval <- shiny::reactive({
+      shiny::req(time())
+      t <- time()
+      if (inherits(t, "Date")) {
+        t <- as.POSIXct(t)
+      }
+
+      # how old is the time data?
+      age <- difftime(time1 = Sys.time(), time2 = t, units = "secs")
+
+      # decide how often to update the UI
+      if (age < 3600) {
+        1e3 * 10 # update every 10 seconds (< 1 hour old)
+      } else if (age < 3600 * 6) {
+        1e3 * 60 # update every minute (< 6 hours old)
+      } else if (age < 3600 * 24) {
+        1e3 * 60 * 5 # update every 5 minutes (< 24 hours old)
+      } else {
+        1e3 * 60 * 60 # update every hour (>= 1 day old)
+      }
+    })
+
+    # update the age of the data
     output$pin_last_updated <- shiny::renderUI({
+      # force re-execution based on adaptive interval
+      shiny::invalidateLater(millis = update_interval(), session = session)
+
       req(time())
       t <- time()
       if (inherits(t, "Date")) {

--- a/outputs/reporting_app/descriptions/national_demographics.md
+++ b/outputs/reporting_app/descriptions/national_demographics.md
@@ -1,0 +1,34 @@
+## National demographics
+
+This chart provides a clear, month-by-month view of **how the national cohort is distributed across demographic groups**, helping you understand which groups make up the cohort and how their relative proportions change over time.
+
+### What the chart shows
+
+- **Cohort size by demographic group**
+  Each bar represents the number of people in the national cohort belonging to a specific demographic group (e.g., age band, ethnic group, deprivation quintile). This makes it easy to see which groups are the largest and how their size shifts over time.
+
+- **Proportional contribution**
+  The label on each bar shows both the raw cohort size and the percentage of the total cohort that group represents. This helps you interpret the scale of each group without needing to compare absolute numbers manually.
+
+- **Month-by-month animation**
+  The chart animates across months, allowing you to observe how the demographic composition evolves. This is particularly useful for spotting emerging trends, seasonal patterns or sudden changes in the underlying population.
+
+- **Interactive hover labels**
+  Hovering over any bar reveals a concise summary including:
+  - the demographic group
+  - the cohort size
+  - the proportion of the national cohort
+  - how many Places contributed non-suppressed values
+
+  This provides additional context without cluttering the visual.
+
+- **Handling of suppressed data**
+  The chart incorporates suppression rules by indicating how many Places contributed usable data. This helps you understand the robustness of each value and highlights where small numbers may affect interpretation.
+
+### Why this view is useful
+
+- Helps you understand who makes up the national cohort and how this changes over time
+- Highlights demographic groups that are growing, shrinking or behaving differently from the rest of the cohort
+- Supports deeper interpretation of Place-level or engagement-level charts by showing the demographic context behind national trends
+- Provides a consistent, intuitive way to explore demographic patterns without needing to manually calculate proportions or track changes month-to-month
+

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -14,18 +14,28 @@ server <- function(input, output, session) {
     df_raw <- pins::pin_reactive_read(
       board = board,
       name = pin_name,
-      interval = 60 * 60 * 1000 # check hourly
+      interval = 1e3 * 60 * 60 # check hourly
     )
 
     # read the pin version for use as a cache key
-    pin_version <- shiny::reactive(
+    pin_version <- shiny::reactive({
+      # check for updates to the version each hour
+      shiny::invalidateLater(
+        millis = 1e3 * 60 * 60 + 1,
+        session = shiny::getDefaultReactiveDomain()
+      )
       pins::pin_meta(board = board, name = pin_name)$version
-    )
+    })
 
-    # read the pin created date (for the version)
-    pin_time <- shiny::reactive(
+    # read the pin created date for data age
+    pin_time <- shiny::reactive({
+      # check for updates to the time each hour
+      shiny::invalidateLater(
+        millis = 1e3 * 60 * 60 + 1,
+        session = shiny::getDefaultReactiveDomain()
+      )
       pins::pin_meta(board = board, name = pin_name)$created
-    )
+    })
   }
 
   # read the pin for issues / changelog

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -167,6 +167,20 @@ server <- function(input, output, session) {
     )
   })
 
+  # update the available demographic splits
+  shiny::observe({
+    shiny::updateSelectInput(
+      session = session,
+      inputId = "selected_demographic",
+      choices = df() |>
+        dplyr::distinct(demographic_type) |>
+        dplyr::filter_out(demographic_type == "Total") |>
+        dplyr::pull(demographic_type) |>
+        unique() |>
+        as.character()
+    )
+  })
+
   # outputs -------------------------------------------------------------------
   ## national dashboard -------------------------------------------------------
   mod_national_overview_server(
@@ -180,6 +194,20 @@ server <- function(input, output, session) {
   mod_national_engagement_server(
     id = "national_engagement",
     df = df
+  )
+
+  ## national demographic splits ----------------------------------------------
+  mod_national_demographics_server(
+    id = "national_demographics",
+    df = df,
+    selected_demographic = shiny::reactive({
+      shiny::req(input$selected_demographic)
+      input$selected_demographic
+    }),
+    df_version = shiny::reactive({
+      shiny::req(pin_version)
+      pin_version
+    })
   )
 
   ## national data coverage ---------------------------------------------------

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -278,6 +278,10 @@ server <- function(input, output, session) {
   # module server call
   mod_place_engagement_server(
     id = "place_engagement",
-    df = df
+    df = df,
+    place = shiny::reactive({
+      req(input$selected_place)
+      input$selected_place
+    })
   )
 }

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -23,6 +23,23 @@ ui <- function(request) {
         # sidebar ----
         sidebar = bslib::sidebar(
           shiny::div(
+            # select a demographic (conditional)
+            shiny::conditionalPanel(
+              condition = "input.national_tabs == 'Demographics'",
+              shiny::selectizeInput(
+                inputId = "selected_demographic",
+                label = "Demographic:",
+                choices = NULL, # will update this reactively in server.R
+                multiple = FALSE
+              )
+            ),
+
+            # bookmark button (conditional)
+            shiny::conditionalPanel(
+              condition = "input.national_tabs == 'Demographics'",
+              shiny::bookmarkButton(label = "Bookmark", width = "100%"),
+            ),
+
             # separator line
             shiny::hr(),
 
@@ -46,8 +63,11 @@ ui <- function(request) {
           # overview metrics
           mod_national_overview_ui("national_overview"),
 
-          # engagemet plot
+          # engagement plot
           mod_national_engagement_ui("national_engagement"),
+
+          # demographics plot
+          mod_national_demographics_ui("national_demographics"),
 
           # data coverage table
           mod_national_coverage_ui("national_coverage"),

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -1,6 +1,5 @@
 ui <- function(request) {
   bslib::page_navbar(
-    # title = "NNHIP scorecard dashboard",
     title = shiny::tags$img(
       src = "logos/nnhip_logo.png",
       style = "height:60px;",
@@ -17,15 +16,22 @@ ui <- function(request) {
 
     # national section --------------------------------------------------------
     bslib::nav_panel(
-      title = "National view",
-      icon = bsicons::bs_icon("map"),
+      value = "national_view",
+      title = shiny::span(
+        bsicons::bs_icon("map"),
+        "National view"
+      ) |>
+        bslib::tooltip(
+          "National-level views of NNHIP data, showing key trends, patterns and progress across all Places.",
+          options = list(trigger = "hover")
+        ),
       bslib::page_sidebar(
         # sidebar ----
         sidebar = bslib::sidebar(
           shiny::div(
             # select a demographic (conditional)
             shiny::conditionalPanel(
-              condition = "input.national_tabs == 'Demographics'",
+              condition = "input.national_tabs == 'demographics'",
               shiny::selectizeInput(
                 inputId = "selected_demographic",
                 label = "Demographic:",
@@ -36,7 +42,7 @@ ui <- function(request) {
 
             # bookmark button (conditional)
             shiny::conditionalPanel(
-              condition = "input.national_tabs == 'Demographics'",
+              condition = "input.national_tabs == 'demographics'",
               shiny::bookmarkButton(label = "Bookmark", width = "100%"),
             ),
 
@@ -80,8 +86,15 @@ ui <- function(request) {
 
     # place section -----------------------------------------------------------
     bslib::nav_panel(
-      title = "Place view",
-      icon = bsicons::bs_icon("pin-map"),
+      value = "place_view",
+      title = shiny::span(
+        bsicons::bs_icon("pin-map"),
+        "Place view"
+      ) |>
+        bslib::tooltip(
+          "Place-level views of NNHIP data, showing local patterns, progress and variation across individual Places.",
+          options = list(trigger = "hover")
+        ),
       bslib::page_sidebar(
         # sidebar ----
         sidebar = bslib::sidebar(
@@ -97,7 +110,7 @@ ui <- function(request) {
 
             # select a metric (conditional)
             shiny::conditionalPanel(
-              condition = "input.place_tabs == 'Funnel plot'",
+              condition = "input.place_tabs == 'funnel_plot'",
               shiny::selectizeInput(
                 inputId = "selected_metric",
                 label = "Metric:",
@@ -108,7 +121,7 @@ ui <- function(request) {
 
             # select a month (conditional)
             shiny::conditionalPanel(
-              condition = "input.place_tabs == 'Funnel plot'",
+              condition = "input.place_tabs == 'funnel_plot'",
               shiny::selectizeInput(
                 inputId = "selected_month",
                 label = "Month:",


### PR DESCRIPTION
closes #32 

This PR delivers a set of improvements across navigation, demographics visualisation, engagement tables and UI reactivity. The changes fall into four main areas:

## 1. Improved navigation with tooltips + refactored conditional panels
- Added `bslib::tooltip()` to all `bslib::nav_panel()` elements to give users clear, at-a-glance descriptions of what each panel contains
- Ensured tooltips trigger on hover only to prevent sticky tooltips after clicking nav items
- Refactored affected `shiny::conditionalPanel()` logic:
  - since tooltips replace the `title` argument, conditional panels could no longer match on panel titles
  - added explicity `value` arguments to all nav panels used in conditional logic

## 2. New national demographics visualisation
- Added a new module `mod_national_demographics.R` to handle UI and server logic for demographic splits.
- Added functions to prepare and visualise demographic breakdowns:
  - `get_data_for_demographic_split()`
  - `display_demographic_split_chart()` (plotly bar chart)
- Updated the national UI:
  - Added a demographic selector visible only on the "Demographics" tab
  - Added a bookmark button that appears only when relevant
  - Integrated `mod_national_demographics_ui()` and `mod_demographics_server()`
- Added markdown guidance to help users interpret the new charts.

## 3. Enhancements to place-level engagement table
- `display_engagement_table()` now supports highlighting a specific Place via `rowStyle`
- `mod_place_engagement_server()` updated to pass the selected Place name through to the table
- `server.R` updated to supply a reactive selected Place to the module

## 4. Reactivity and bug fixes
- **Trendline bug fix**:
  - Resolved disappearing sparklines caused by per-cell htmlwidget rendering
  - Using `data = df_dashboard` ensures a shared widget and stable hover behaviour
- **National engagement cohort size fix**:
  - Corrected overcounting caused by summing all "Total" rows across metrics
  - Now uses the median cohort size across metrics per Place before summing
- **Pin metadata reactivity improvements**:
  - Added `invalidateLater()` to refresh pin version/time hourly
- **Last-updated timer improvements**:
  - Added tapered refresh intervals for `output$pin_last_updated()` to show minute-level freshness when data is new, falling back to hourly updates when older.