### PR TITLE
:zap: Optimises the monthly validation and ingestion by reusing the MS Teams folder object

### DIFF
--- a/R/01_prepare_app_data.R
+++ b/R/01_prepare_app_data.R
@@ -11,9 +11,12 @@
 
 source(here::here("R", "data_ingest.R"))
 
+# authenticate with the MS Teams folders
+folder <- get_ms_teams_folder()
+
 # --- Validation checks -------------------------------------------------------
 # run a validation check on submissions
-validation <- validate_monthly_submissions()
+validation <- validate_monthly_submissions(ms_teams_folder = folder)
 
 # if issues detected then investigate:
 validation$issues |> View()
@@ -25,4 +28,4 @@ launch_app_with_test_data()
 # --- Process data ------------------------------------------------------------
 
 # when ready to update the data, run this:
-update_pinned_data_for_month()
+update_pinned_data_for_month(ms_teams_folder = folder)

--- a/R/data_ingest.R
+++ b/R/data_ingest.R
@@ -736,15 +736,22 @@ ingest_data <- function(month = NULL, ms_teams_folder = NULL) {
 #' refereshes a combined dataset containing all months' submissions.
 #'
 #' @returns Invisibly returns TRUE on success
-update_pinned_data_for_month <- function() {
+update_pinned_data_for_month <- function(ms_teams_folder = NULL) {
+  # connect to the Teams / SharePoint site
+  if (is.null(ms_teams_folder)) {
+    folder <- get_ms_teams_folder()
+  } else {
+    folder <- ms_teams_folder
+  }
+
   # get a reference to the teams folder
-  ms_teams_folder <- get_ms_teams_folder()
+  # ms_teams_folder <- get_ms_teams_folder()
 
   # collate the submissions for a month
-  df_month <- collate_submissions_for_month(ms_teams_folder = ms_teams_folder)
+  df_month <- collate_submissions_for_month(ms_teams_folder = folder)
 
   # get the issues / changelog
-  df_issues <- get_issues_log(ms_teams_folder = ms_teams_folder)
+  df_issues <- get_issues_log(ms_teams_folder = folder)
 
   # get the month_id (textual representation of the month in YYYY-MM format)
   month_id <-
@@ -991,9 +998,16 @@ create_placeholder_pins <- function(from = "2026-02-01", to = "2027-3-01") {
 #' result <- validate_monthly_submissions()
 #' result$issues
 #' }
-validate_monthly_submissions <- function() {
+validate_monthly_submissions <- function(ms_teams_folder = NULL) {
+  # connect to the Teams / SharePoint site
+  if (is.null(ms_teams_folder)) {
+    folder <- get_ms_teams_folder()
+  } else {
+    folder <- ms_teams_folder
+  }
+
   # ingest the data
-  df <- collate_submissions_for_month()
+  df <- collate_submissions_for_month(ms_teams_folder = folder)
 
   # run validation checks
   issues <- list()


### PR DESCRIPTION
closes #36 

This update streamlines the monthly validation and ingestion workflow by creating the MS Teams / SharePoint folder object once and passing it through the process, avoiding repeated authentication overhead.

## Key changes
- `01_prepare_app_data.R` now creates the MS Teams folder object explicitly and passes it to both `validate_monthly_submissions()` and `update_pinned_data_for_month()`.
- `update_pinned_data_for_month()` has been udpated to accept an optional folder object (default: `NULL`). If none is provided, it will create the folder object internally.
- `validate_monthly_submissions()` has been updated in the same way - accepting an optional folder object and generating one only when needed.

This reduces redundant authentication calls and speeds up validation and ingestion across mutiple months.