### PR TITLE
38 improve readability engagement

### DIFF
--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -2188,6 +2188,13 @@ display_national_engagement_plot <- function(df) {
     ann_list <- add_annotation_to_list(df = df, idx = idx, str_desc = label)
   }
 
+  # define the x-axis range
+  one_month <- lubridate::period(num = 2, units = "weeks")
+  xaxis_range <- c(
+    df$month_dt |> min(na.rm = TRUE) - one_month,
+    df$month_dt |> max(na.rm = TRUE) + one_month
+  )
+
   # construct the plot
   plotly::plot_ly(
     data = df,
@@ -2221,7 +2228,8 @@ display_national_engagement_plot <- function(df) {
       xaxis = list(
         tickformat = "%b %Y",
         dtick = "M1",
-        title = "Submission period"
+        title = "Submission period",
+        range = xaxis_range
       ),
       yaxis = list(title = ""),
       # add the annotations to the plot

--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -2189,10 +2189,10 @@ display_national_engagement_plot <- function(df) {
   }
 
   # define the x-axis range
-  one_month <- lubridate::period(num = 2, units = "weeks")
+  buffer <- lubridate::period(num = 2, units = "weeks")
   xaxis_range <- c(
-    df$month_dt |> min(na.rm = TRUE) - one_month,
-    df$month_dt |> max(na.rm = TRUE) + one_month
+    df$month_dt |> min(na.rm = TRUE) - buffer,
+    df$month_dt |> max(na.rm = TRUE) + buffer
   )
 
   # construct the plot


### PR DESCRIPTION
closes #38 

This PR adds a two-week buffer at the start and at the end of the x-axis for the national engagement chart. This gives the data points a bit more breathing room and makes the chart easier to engage with.