### PR TITLE
:memo: increases visibility of view descriptions

### DIFF
--- a/outputs/reporting_app/R/mod_national_changelog.R
+++ b/outputs/reporting_app/R/mod_national_changelog.R
@@ -19,7 +19,8 @@ mod_national_changelog_ui <- function(id) {
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(
-        open = FALSE,
+        open = TRUE,
+        width = "400px",
         shiny::includeMarkdown("descriptions/national_changelog.md")
       ),
       bslib::card_body(

--- a/outputs/reporting_app/R/mod_national_coverage.R
+++ b/outputs/reporting_app/R/mod_national_coverage.R
@@ -19,7 +19,8 @@ mod_national_coverage_ui <- function(id) {
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(
-        open = FALSE,
+        open = TRUE,
+        width = "400px",
         shiny::includeMarkdown("descriptions/national_coverage.md")
       ),
       bslib::card_body(

--- a/outputs/reporting_app/R/mod_national_demographics.R
+++ b/outputs/reporting_app/R/mod_national_demographics.R
@@ -20,7 +20,8 @@ mod_national_demographics_ui <- function(id) {
       fillable = TRUE,
       open = FALSE,
       sidebar = bslib::sidebar(
-        open = FALSE,
+        open = TRUE,
+        width = "400px",
         shiny::includeMarkdown("descriptions/national_demographics.md")
       ),
       bslib::card_body(

--- a/outputs/reporting_app/R/mod_national_engagement.R
+++ b/outputs/reporting_app/R/mod_national_engagement.R
@@ -20,7 +20,8 @@ mod_national_engagement_ui <- function(id) {
       fillable = TRUE,
       open = FALSE,
       sidebar = bslib::sidebar(
-        open = FALSE,
+        open = TRUE,
+        width = "400px",
         shiny::includeMarkdown("descriptions/national_engagement.md")
       ),
       bslib::card_body(

--- a/outputs/reporting_app/R/mod_national_overview.R
+++ b/outputs/reporting_app/R/mod_national_overview.R
@@ -19,7 +19,8 @@ mod_national_overview_ui <- function(id) {
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(
-        open = FALSE,
+        open = TRUE,
+        width = "400px",
         shiny::includeMarkdown("descriptions/national_overview.md")
       ),
       bslib::card_body(

--- a/outputs/reporting_app/R/mod_place_engagement.R
+++ b/outputs/reporting_app/R/mod_place_engagement.R
@@ -20,7 +20,8 @@ mod_place_engagement_ui <- function(id) {
       fillable = TRUE,
       open = FALSE,
       sidebar = bslib::sidebar(
-        open = FALSE,
+        open = TRUE,
+        width = "400px",
         shiny::includeMarkdown("descriptions/place_engagement.md")
       ),
       bslib::card_body(

--- a/outputs/reporting_app/R/mod_place_funnel.R
+++ b/outputs/reporting_app/R/mod_place_funnel.R
@@ -19,7 +19,8 @@ mod_place_funnel_ui <- function(id) {
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(
-        open = FALSE,
+        open = TRUE,
+        width = "400px",
         shiny::includeMarkdown("descriptions/place_funnel.md")
       ),
       bslib::card_body(

--- a/outputs/reporting_app/R/mod_place_overview.R
+++ b/outputs/reporting_app/R/mod_place_overview.R
@@ -19,7 +19,8 @@ mod_place_overview_ui <- function(id) {
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(
-        open = FALSE,
+        open = TRUE,
+        width = "400px",
         shiny::includeMarkdown("descriptions/place_overview.md")
       ),
       bslib::card_body(


### PR DESCRIPTION
closes #40 

This PR sets all sidebars to visible by default with a 400px width. This ensures that users are presented with the description of the plot and what it intends to show and can be dismissed with the chevron.
