### PR TITLE
Reconstruct submission view, improve template process and adds an additional ingestion data check

### DIFF
--- a/R/data_ingest.R
+++ b/R/data_ingest.R
@@ -25,7 +25,7 @@ get_ms_teams_folder <- function(base_folder = "Neighbourhood DC") {
   channel_name <- Sys.getenv("su_channel")
   if (team_name == "" || channel_name == "") {
     cli::cli_abort(
-      "Environment variables {.var su_team} and {.var su_channel} must be set."
+      "Environment variables {.var {su_team}} and {.var {su_channel}} must be set."
     )
   }
 
@@ -362,7 +362,7 @@ get_submissiontemplate_header <- function(df_raw) {
 #' }
 process_submissiontemplate_data <- function(
   df_raw,
-  suppression_marker = c("*", "", "<5", "-"),
+  suppression_marker = c("*", "", "<5", "-", "<6"),
   # suppression_marker = c("*", ""),
   filepath = NULL
 ) {
@@ -1022,6 +1022,8 @@ validate_monthly_submissions <- function(ms_teams_folder = NULL) {
   issues[[length(issues) + 1]] <- check_month_consistency(df = df)
   # check 5: all metric_block | metric_details combo are consistent
   # issues[[length(issues) + 1]] <- check_metric_alignment(df = df)
+  # check 6: all placs have the same number of records
+  issues[[length(issues) + 1]] <- check_place_consistency(df = df)
 
   # combine issues into a single data frame
   issues_df <- if (length(issues) == 0) {
@@ -1294,6 +1296,70 @@ check_month_consistency <- function(df) {
   }
 }
 
+#' Check consistency of record counts across places
+#'
+#' @description
+#' Identifies places that have an unexpected number of records compared with
+#' the modal (most common) place count. This helps detect re-submissions which
+#' have not been handled correctly.
+#'
+#' @details
+#' The function groups the input data frame by `place` and counts the number of
+#' records associated with each place. Places whose record count differs from
+#' the maximum (i.e. the modal count) are flagged as suspicious.
+#'
+#' If no inconsistencies are found, the function returns an empty issue schema.
+#'
+#' @param df data frame of ingested metrics data
+#'
+#' @returns A data frame of issues (possibly empty) with fields suitable for
+#' logging in the data-issues log
+check_place_consistency <- function(df) {
+  # define suspicious counts - places with more records than the modal place count
+  suspicious <- df |>
+    dplyr::mutate(counter = 1L) |>
+    dplyr::summarise(
+      n_records = sum(counter, na.rm = TRUE),
+      .by = place
+    ) |>
+    dplyr::filter_out(n_records == mode_val(n_records))
+
+  # if nothing suspicious, return an empty tibble
+  if (nrow(suspicious) == 0) {
+    return(empty_issue_schema())
+  }
+
+  # otherwise return structured issues
+  if (nrow(suspicious) > 0) {
+    places_sus <- suspicious$place |> unique() |> sort()
+
+    cli::cli_alert_danger(
+      "Places found with an unusual number of records: {.val {places_sus}}. Check the submissions folder for duplicate entries or for re-submissions which have not been properly excluded.",
+      wrap = TRUE
+    )
+
+    suspicious |>
+      dplyr::mutate(
+        issue_type = "Place anomaly",
+        description = "Places with unusual number of records",
+        place = place,
+        field = "place",
+        value = paste(place),
+        impact = "Submission is likely to be duplicate / re-submission",
+        status = "Open"
+      ) |>
+      dplyr::select(
+        issue_type,
+        description,
+        place,
+        field,
+        value,
+        impact,
+        status
+      )
+  }
+}
+
 #' Check for misalignment in metric definitions
 #'
 #' @description
@@ -1390,4 +1456,27 @@ launch_app_with_test_data <- function() {
       browseURL(url)
     }
   )
+}
+
+
+#' Return the mode value
+#'
+#' @description
+#' Works out the mode value from a given vector of values.
+#'
+#' @details
+#' Code taken from here:
+#' https://stackoverflow.com/questions/2547402/how-to-find-the-statistical-mode
+#'
+#' @param x A vector of values
+#'
+#' @returns A numeric value containing the modal value
+#'
+#' @examples
+#' \dontrun{
+#' mode_val(c(3, 5, 5, 9, 5, 1, 3, 5))
+#' }
+mode_val <- function(x) {
+  ux <- unique(x)
+  ux[which.max(tabulate(match(x, ux)))]
 }

--- a/outputs/reporting_app/R/dashboard_helpers.R
+++ b/outputs/reporting_app/R/dashboard_helpers.R
@@ -1453,6 +1453,231 @@ display_engagement_table <- function(df, place_highlight = NULL) {
     )
 }
 
+#' Prepare wide-format data for submission-style display
+#'
+#' @description
+#' This function filters the NNHIP dataset to a selected place and month,
+#' applies suppression rules, orders demographic categories and pivots the data
+#' into the wide format used in the original submission template.
+#'
+#' @details
+#' The function performs several steps:
+#' - Validates that the selected Place and month exist in the dataset
+#' - Filters to the requested Place and month
+#' - Applies suppression rules, converting suppressed avlues to `"*"`
+#' - Orders demographic types to match the submission template
+#' - Converts values to character strings for pivoting
+#' - Pivots the data wider, producing one column per demographic category
+#' - Reorders columns so that `Total` appears before age groups
+#'
+#' @param df A data frame containing the long-format NNHIP metrics
+#' @param selected_place A single place name to filter for (e.g., "East Kent")
+#' @param selected_month A zoo::yearmon value indicating the month to filter for
+#'
+#' @returns A wide-format data frame suitable for display using {gt}
+#'
+#' @examples
+#' \dontrun{
+#' get_data_for_submission_view(df, "East Kent", zoo::as.yearmon("Mar 2026"))
+#' }
+get_data_for_submission_view <- function(df, selected_place, selected_month) {
+  # defensive checks
+  df_check <- df |> dplyr::distinct(place, month_zoo)
+
+  if (!selected_place %in% df_check$place) {
+    shiny::validate(
+      shiny::need(
+        expr = FALSE,
+        message = glue::glue("No data available for place: {selected_place}")
+      )
+    )
+  }
+
+  if (!selected_month %in% df_check$month_zoo) {
+    shiny::validate(
+      shiny::need(
+        expr = FALSE,
+        message = glue::glue("No data available for month: {selected_month}")
+      )
+    )
+  }
+
+  if (
+    df_check |>
+      dplyr::filter(place == selected_place, month_zoo == selected_month) |>
+      nrow() ==
+      0
+  ) {
+    shiny::validate(
+      shiny::need(
+        expr = FALSE,
+        message = glue::glue(
+          "{selected_place} doesn't have data for the month of {selected_month}"
+        )
+      )
+    )
+  }
+
+  # produce the data
+  df_return <-
+    df |>
+
+    # filter to just the selected place
+    dplyr::filter(
+      place == selected_place,
+      month_zoo == selected_month
+    ) |>
+
+    # limit the data to essential columns
+    dplyr::select(
+      place,
+      month_zoo,
+      metric_id,
+      metric_block,
+      metric_type,
+      demographic_type,
+      demographic_value,
+      value_type,
+      value,
+      value_suppressed,
+      metric
+    ) |>
+
+    # convert some data
+    dplyr::mutate(
+      # re-create the ordering
+      demographic_type = factor(
+        x = demographic_type,
+        levels = c(
+          "Total",
+          "Age Group",
+          "Ethnic Group",
+          "Deprivation Quintile"
+        )
+      ),
+      # round rates to two digits
+      value = round(x = value, digits = 2),
+
+      # convert values to strings (allow to be combined with '*')
+      value_s = dplyr::if_else(
+        condition = value_suppressed,
+        true = "*",
+        false = as.character(value)
+      )
+    ) |>
+    # trim fields no longer needed
+    dplyr::select(-c(value_suppressed, value)) |>
+
+    # pivot the data wider
+    dplyr::arrange(demographic_type) |>
+    tidyr::pivot_wider(
+      names_from = c(demographic_type, demographic_value),
+      values_from = value_s
+    ) |>
+
+    # prepare for output
+    dplyr::arrange(
+      place,
+      month_zoo,
+      metric_block,
+      value_type
+    )
+  # |>
+  # dplyr::relocate(Total_Total, .before = `Age Group_18-19`)
+
+  if (all(c("Total_Total", "Age Group_18-19") %in% names(df_return))) {
+    df_return <- dplyr::relocate(
+      df_return,
+      Total_Total,
+      .before = `Age Group_18-19`
+    )
+  }
+  # return the result
+  return(df_return)
+}
+
+#' Display a submission-style table using {gt}
+#'
+#' @description
+#' This function takes the wide-format output from
+#' `get_data_for_submission_view()` and renders it as a formatted {gt} table that
+#' visually resembles the original NNHIP submission spreadsheet.
+#'
+#' @details
+#' The table includes:
+#' - Row groups based on the metric description
+#' - Stub labels based on {value_type}
+#' - Column spanners for age, ethnicity and deprivation categories
+#' - Suppression indicators and compact value-type labels (N/D/R)
+#' - A wide layout suitable for horizontal scrolling in Shiny
+#'
+#' @param df A wide-format data frame produced by `get_data_for_submission_view()`
+#' @param selected_place A character string used as the table title
+#' @param selected_month A character or {yearmon} value used as the subtitle
+#'
+#' @returns A {gt} table object
+#'
+#' @examples
+#' \dontrun{
+#' df_wide <- get_data_for_submission(df, "East Kent", zoo::as.yearmon("Mar 2026"))
+#' display_submission_view_table(df_wide, "East Kent", "Mar 2026")
+#' }
+display_submission_view_table <- function(df, selected_place, selected_month) {
+  # produce the formatted table
+  t <-
+    df |>
+    gt::gt(
+      groupname_col = "metric",
+      row_group_as_column = TRUE,
+      rowname_col = "value_type"
+    ) |>
+    # sort out the columns
+    gt::cols_label(Total_Total = "Total") |>
+    gt::tab_spanner_delim(
+      columns = c(`Age Group_18-19`:`Deprivation Quintile_Not known`),
+      delim = "_"
+    ) |>
+    gt::cols_hide(
+      columns = c(place, month_zoo, metric_block, metric_id, metric_type)
+    ) |>
+    # try to give the metric description enough space
+    # (not likely as very wide table, but doing anyway)
+    gt::cols_width(gt::row_group() ~ gt::px(200)) |>
+    # adding title and captions
+    gt::tab_header(
+      title = selected_place,
+      subtitle = selected_month
+    ) |>
+    gt::tab_caption(
+      caption = "'*' = Suppressed data | 'N' = numerator | 'D' = denominator | 'R' = rate per 1,000"
+    ) |>
+    # styling and formatting
+    gt::tab_style(
+      style = gt::cell_borders(
+        sides = c("left"),
+        color = "#dcdde1",
+        weight = gt::px(2)
+      ),
+      locations = gt::cells_body(
+        columns = c(
+          `Age Group_18-19`,
+          `Ethnic Group_White`,
+          `Deprivation Quintile_1`
+        )
+      )
+    ) |>
+    # re-label the value types to save horizontal space
+    gt::text_case_match(
+      .replace = "all",
+      .locations = gt::cells_stub(rows = gt::everything()),
+      "count" ~ "N",
+      "patients" ~ "D",
+      "rate_per_1000" ~ "R"
+    )
+
+  # return the result
+  return(t)
+}
 
 # National views --------------------------------------------------------------
 

--- a/outputs/reporting_app/R/mod_place_submission.R
+++ b/outputs/reporting_app/R/mod_place_submission.R
@@ -1,0 +1,68 @@
+# --- Submission view (Places) ------------------------------------------------
+
+# ui ----
+mod_place_submission_ui <- function(id) {
+  # set up namespacing
+  ns <- shiny::NS(id)
+
+  # define the UI
+  bslib::nav_panel(
+    value = "submission_view",
+    title = shiny::span(
+      bsicons::bs_icon("table"),
+      "Submission"
+    ) |>
+      bslib::tooltip(
+        "View of the underlying submitted data, formatted like the original template to support debugging and validation.",
+        options = list(trigger = "hover")
+      ),
+    bslib::layout_sidebar(
+      fillable = TRUE,
+      open = FALSE,
+      sidebar = bslib::sidebar(
+        open = TRUE,
+        width = "400px",
+        shiny::includeMarkdown("descriptions/place_submission_view.md")
+      ),
+      bslib::card_body(
+        gt::gt_output(ns("submission_table"))
+      )
+    )
+  )
+}
+
+# server ----
+mod_place_submission_server <- function(id, df, place, month, pin_version) {
+  shiny::moduleServer(id, function(input, output, session) {
+    # cache data for place:month for improved UX ----
+    df_submission <- shiny::reactive({
+      req(df(), pin_version(), place(), month())
+
+      get_data_for_submission_view(
+        df = df(),
+        selected_place = place(),
+        selected_month = month()
+      )
+    }) |>
+      shiny::bindCache(
+        pin_version(),
+        place(),
+        month()
+      )
+
+    # render the table (cached)----
+    output$submission_table <- gt::render_gt({
+      req(df_submission(), place(), month())
+      display_submission_view_table(
+        df = df_submission(),
+        selected_place = place(),
+        selected_month = month()
+      )
+    }) |>
+      shiny::bindCache(
+        pin_version(),
+        place(),
+        month()
+      )
+  })
+}

--- a/outputs/reporting_app/descriptions/place_submission_view.md
+++ b/outputs/reporting_app/descriptions/place_submission_view.md
@@ -1,0 +1,31 @@
+## Submission view
+
+This view provides a **reconstruction of the original submitted dataset** for the selected Place and month, formatted to mirror the layout of the NNHIP submission template. It shows the values exactly as they were provided (after suppression rules are applied), making it easier to understand how the dashboard's metrics are derived.
+
+### What the table shows
+
+- **Metric grouping** Each metric is displayed in the same block structure used in the submission template, including counts, denominators and calculated rates.
+
+- **Values types (N / D / R)** The rows represent the different value types submitted for each metric:
+
+  - **N** = numerator
+
+  - **D** = denominator
+
+  - **R** = rate per 1,000 patients
+
+- **Demographic breakdowns** Columns are organised into the same demographic groups as the submission template: **Total**, **Age Group**, **Ethnic Group** and **Deprivation Quintile**. Each demographic category expands into its individual values (e.g., age bands, ethnic categories, IMD quintiles).
+
+- **Suppressed values** Any values suppressed in the original submission are shown as `"*"`, matching the behaviour applied during data processing.
+
+### Why this view is useful
+
+-   Provides a transparent, in-app way to inspect the underlying submitted data without opening external files.
+
+-   Helps diagnose unexpected or anomalous dashboard values by showing the raw inputs used in calculations.
+
+-   Mirrors the structure of the submission template, making it easier to cross-reference and validate data.
+
+-   Reduces the need for manual file-hunting and comparison, speeding up debugging and quality-assurance workflows.
+
+-   Supports clearer conversations with data providers by showing precisely what the data looks like following processing.

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -136,6 +136,27 @@ server <- function(input, output, session) {
       dplyr::pull(metric)
   })
 
+  # ui reactives --------------------------------------------------------------
+  input_selected_place <- shiny::reactive({
+    shiny::req(input$selected_place)
+    input$selected_place
+  })
+
+  input_selected_metric <- shiny::reactive({
+    req(input$selected_metric)
+    input$selected_metric
+  })
+
+  input_selected_month <- shiny::reactive({
+    req(input$selected_month)
+    input$selected_month |> zoo::as.yearmon()
+  })
+
+  input_selected_demographic <- shiny::reactive({
+    shiny::req(input$selected_demographic)
+    input$selected_demographic
+  })
+
   # update ui inputs ----------------------------------------------------------
   # update the data refresh time
   mod_utils_last_updated_server(
@@ -210,10 +231,7 @@ server <- function(input, output, session) {
   mod_national_demographics_server(
     id = "national_demographics",
     df = df,
-    selected_demographic = shiny::reactive({
-      shiny::req(input$selected_demographic)
-      input$selected_demographic
-    }),
+    selected_demographic = input_selected_demographic,
     df_version = shiny::reactive({
       shiny::req(pin_version)
       pin_version
@@ -234,19 +252,13 @@ server <- function(input, output, session) {
 
   ## place dashboard ----------------------------------------------------------
   # card header text
-  output$place_header <- shiny::renderText({
-    shiny::req(input$selected_place)
-    input$selected_place
-  })
+  output$place_header <- input_selected_place
 
   # module server call
   mod_place_overview_server(
     id = "place_overview",
     df = df,
-    place = shiny::reactive({
-      shiny::req(input$selected_place)
-      input$selected_place
-    }),
+    place = input_selected_place,
     month_current = filtered_month_current,
     month_previous = filtered_month_previous
   )
@@ -256,32 +268,33 @@ server <- function(input, output, session) {
   mod_place_funnel_server(
     id = "place_funnel",
     df = df_selected_month,
-    place = shiny::reactive({
-      req(input$selected_place)
-      input$selected_place
-    }),
-    metric = shiny::reactive({
-      req(input$selected_metric)
-      input$selected_metric
-    }),
-    month = shiny::reactive({
-      req(input$selected_month)
-      input$selected_month |> zoo::as.yearmon()
-    }),
+    place = input_selected_place,
+    metric = input_selected_metric,
+    month = input_selected_month,
     df_version = shiny::reactive({
       req(pin_version)
       pin_version
     })
   )
 
-  ## engagement table ---------------------------------------------------------
+  ## place engagement table ---------------------------------------------------
   # module server call
   mod_place_engagement_server(
     id = "place_engagement",
     df = df,
-    place = shiny::reactive({
-      req(input$selected_place)
-      input$selected_place
+    place = input_selected_place
+  )
+
+  ## place submission table ---------------------------------------------------
+  # module server call
+  mod_place_submission_server(
+    id = "place_submission",
+    df = df,
+    place = input_selected_place,
+    month = input_selected_month,
+    pin_version = shiny::reactive({
+      req(pin_version)
+      pin_version
     })
   )
 }

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -121,7 +121,7 @@ ui <- function(request) {
 
             # select a month (conditional)
             shiny::conditionalPanel(
-              condition = "input.place_tabs == 'funnel_plot'",
+              condition = "input.place_tabs == 'funnel_plot' || input.place_tabs == 'submission_view'",
               shiny::selectizeInput(
                 inputId = "selected_month",
                 label = "Month:",
@@ -164,7 +164,10 @@ ui <- function(request) {
             mod_place_funnel_ui("place_funnel"),
 
             # engagement table ----
-            mod_place_engagement_ui("place_engagement")
+            mod_place_engagement_ui("place_engagement"),
+
+            # submission view table ----
+            mod_place_submission_ui("place_submission")
           )
         )
       )


### PR DESCRIPTION
closes #42 

This PR introduces a set of enhancements to support reconstruction of the submission template in-app, improvements to the data-ingestion robustness and streamlines the Shiny module structure.

## Key changes
### Submission view reconstruction
- Added a new UI/server module for the *submission_view*, enabling users to access a reconstructed version of a given submission.
- Added two supporting functions:
  - A function to generate the wide-format dataset required for reconstruction
  - A function to render this dataset as **gt**-formatted HTML table
- Updated `ui.R` to include the submission view and ensured the month selector is visible for both `funnel_plot` and `submission_view`.

### Template processing improvements
- Added `"<6"` to the list of suppression markers in `process_submissiontemplate_data()`.
- Improved error handling for missing environment variables in `{cli}` abort messages

### Place-level consistency checks
- Added `check_place_consistency()`, which identifies places with a non-modal number of records (useful for detecting double-submissions).
- Added `mode_val()`, a helper that returns the modal value from a vector.

### Shiny server refactor
- Added a call to `mod_place_submission_server()` with required parameters
- Replaced multiple repeated `shiny::reactive()` calls with dedicated reactive objects for place, month, metric and demographic inputs, improving readability and maintainability of `server.R`.

### Documentation
- Added markdown text to accompany the `place_submission` view.