### PR TITLE
:bug: Corrects issue with National Overview Table

### DIFF
--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -112,6 +112,17 @@ server <- function(input, output, session) {
       zoo::yearmon()
   })
 
+  # list of months for the national views
+  national_months <- shiny::reactive({
+    req(df())
+
+    df() |>
+      dplyr::pull(month_zoo) |>
+      unique() |>
+      sort() |>
+      zoo::yearmon()
+  })
+
   # get the latest / current month
   filtered_month_current <- shiny::reactive({
     req(filtered_months())
@@ -119,11 +130,23 @@ server <- function(input, output, session) {
     filtered_months() |> tail(n = 1L)
   })
 
+  national_month_current <- shiny::reactive({
+    req(national_months())
+
+    national_months() |> tail(n = 1L)
+  })
+
   # get the month before the current one
   filtered_month_previous <- shiny::reactive({
     req(filtered_months())
 
     filtered_months() |> tail(n = 2L) |> min()
+  })
+
+  national_month_previous <- shiny::reactive({
+    req(national_months())
+
+    national_months() |> tail(n = 2L) |> min()
   })
 
   # get a list of metrics
@@ -217,8 +240,8 @@ server <- function(input, output, session) {
   mod_national_overview_server(
     id = "national_overview",
     df = df,
-    month_current = filtered_month_current,
-    month_previous = filtered_month_previous
+    month_current = national_month_current,
+    month_previous = national_month_previous
   )
 
   ## national engagement plot -------------------------------------------------

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -34,7 +34,7 @@ ui <- function(request) {
           target = "_blank",
           style = "text-decoration: none; color: inherit;",
           bsicons::bs_icon("file-earmark-pdf"),
-          htmltools::span("Measurement Guide") |>
+          htmltools::span("Measurement guide") |>
             bslib::tooltip(
               "Guidance on how NNHIP measures are defined and how Places should implement them",
               options = list(trigger = "hover")


### PR DESCRIPTION
closes #50 

Addresses a bug which resulted in the national overview table not showing the previous month's activity:
- adds a new reactive to list all months available for display nationall `national_months`,
- uses `national_months` to produce two other reactives `national_month_current` and `national_month_previous` which identify the current and previous months based on national data
- updates the parameters for `mod_national_overview_server` to use the new reactives instead of the previous reactives which were sensitive to the selected Place (`filtered_month_current` and `filtered_month_previous`).
- addresses a minor typo in the server.R file