### PR TITLE
:sparkles: adds a guided tour of the app

### DIFF
--- a/outputs/reporting_app/R/conductor.R
+++ b/outputs/reporting_app/R/conductor.R
@@ -1,0 +1,103 @@
+# This is the {conductor} script to provide a brief tour of the app
+# Designed to help orient new users to the app
+conductor <- conductor::Conductor$new()$step(
+  title = "🧭 Welcome to the NNHIP Dashboard",
+  text = shiny::HTML(
+    "<p>This tour will introduce the main navigation, sidebars and view descriptions to help you get started exploring NNHIP data.</p>"
+  )
+)$step(
+  el = "a .documentation-menu",
+  title = "Documentation",
+  text = shiny::HTML(
+    "<p>Find the <strong>Measurement Guide</strong> and <strong>Submission Template</strong> here.</p>
+    <p>These documents explain how measures are defined and how to submit monthly data.</p>"
+  ),
+  tab = "national_view",
+  tabId = "nav_main"
+)$step(
+  el = "a .nav-national",
+  title = "National View",
+  text = shiny::HTML(
+    "<p>Use the National View to explore trends, patterns and variation across all Places.</p>"
+  ),
+  tab = "national_overview",
+  tabId = "national_tabs"
+)$step(
+  el = "#national_tabs",
+  title = "National Views",
+  text = shiny::HTML(
+    "<p>Each tab in this menu provides a different national-level view, including:</p>
+    <ul>
+      <li><strong>Overview</strong> - key monthly metrics</li>
+      <li><strong>Demographics</strong> - variation across groups</li>
+      <li><strong>Coverage</strong> - data completeness</li>
+      <li><strong>Changelog</strong> - recent updates and issues</li>
+    </ul>"
+  ),
+  # ensure on the national view of the main navbar
+  tab = "national_view",
+  tabId = "nav_main"
+)$step(
+  el = "#national_overview_description",
+  title = "View Description",
+  text = shiny::HTML(
+    "<p>Each view includes a description explaining what the chart or table shows and how to interpret it.</p>
+    <p>You can collapse or expand this sidebar using the chevron button (<code><</code>) at the top.</p>"
+  ),
+  # ensure the 'overview' tab is selected in the 'national_tabs' navbar
+  tab = "overview_national",
+  tabId = "national_tabs"
+)$step(
+  el = "#national_overview",
+  title = "Interactive Views",
+  text = shiny::HTML(
+    "<p>Most views in the dashboard are interactive:</p>
+    <ul>
+      <li><strong>Tables</strong> - click column headings to sort and scroll to see more rows.</li>
+      <li><strong>Charts</strong> - hover over points for additional information and use the toolbar to zoom or reset.</li>
+    </ul>
+    <p>Try interacting with tables and charts to explore the data in more depth.</p>
+    "
+  )
+)$step(
+  el = "a .nav-place",
+  title = "Place View",
+  text = shiny::HTML(
+    "<p>Switch to the Place View to explore data for individual Places, including funnel plots, submissions and engagement.</p>",
+  ),
+  tab = "place_view",
+  tabId = "nav_main"
+)$step(
+  el = "#place_sidebar",
+  title = "Sidebar Controls",
+  text = shiny::HTML(
+    "<p>This sidebar contains the key inputs for exploring Place-level data:</p>
+    <ul>
+      <li><strong>Place selector</strong> - choose which Place you want to view.</li>
+      <li><strong>Metric and Month selectors</strong> - appear when relevant, such as in the Funnel Plot or Submission View.</li>
+      <li><strong>Bookmark button</strong> - save your current view so you can return to it later.</li>
+      <li><strong>Last updated panel</strong> - shows when the data was most recently refreshed.</li>
+    </ul>
+    <p>You can collapse or expand this sidebar at any time using the chevron button (<code><</code>) at the top.</p>
+    "
+  ),
+  tab = "place_view",
+  tabId = "nav_main"
+)$step(
+  el = "#place_header_title",
+  position = "bottom-start",
+  title = "Place Header",
+  text = shiny::HTML(
+    "<p>This title shows the name of the selected Place.</p>
+    <p>All views in this section update automatically when you choose a different Place from the sidebar.</p>"
+  ),
+  tab = "place_view",
+  tabId = "nav_main"
+)$step(
+  title = "✅ You're ready to explore",
+  text = shiny::HTML(
+    "<p>You now know how to navigate the dashboard.</p>
+    <p>You can restart this tour anytime using the help button in the navbar.</p>"
+  ),
+  buttons = list(list(text = "End tour", action = "next"))
+)

--- a/outputs/reporting_app/R/mod_national_demographics.R
+++ b/outputs/reporting_app/R/mod_national_demographics.R
@@ -17,6 +17,7 @@ mod_national_demographics_ui <- function(id) {
         options = list(trigger = "hover")
       ),
     bslib::layout_sidebar(
+      id = "national_overview_description",
       fillable = TRUE,
       open = FALSE,
       sidebar = bslib::sidebar(
@@ -25,7 +26,9 @@ mod_national_demographics_ui <- function(id) {
         shiny::includeMarkdown("descriptions/national_demographics.md")
       ),
       bslib::card_body(
-        plotly::plotlyOutput(ns("demographics_plot"))
+        id = "national_overview",
+        plotly::plotlyOutput(ns("demographics_plot")),
+        fill = TRUE
       )
     )
   )

--- a/outputs/reporting_app/R/mod_national_overview.R
+++ b/outputs/reporting_app/R/mod_national_overview.R
@@ -19,11 +19,13 @@ mod_national_overview_ui <- function(id) {
     bslib::layout_sidebar(
       fillable = TRUE,
       sidebar = bslib::sidebar(
+        id = "national_overview_description",
         open = TRUE,
         width = "400px",
         shiny::includeMarkdown("descriptions/national_overview.md")
       ),
       bslib::card_body(
+        id = "national_overview",
         reactable::reactableOutput(ns("national_table")),
         fill = TRUE
       )

--- a/outputs/reporting_app/server.R
+++ b/outputs/reporting_app/server.R
@@ -180,6 +180,12 @@ server <- function(input, output, session) {
     input$selected_demographic
   })
 
+  # ui observers --------------------------------------------------------------
+  shiny::observeEvent(input$start_tour, {
+    # test - conductor
+    conductor$init()$start()
+  })
+
   # update ui inputs ----------------------------------------------------------
   # update the data refresh time
   mod_utils_last_updated_server(

--- a/outputs/reporting_app/ui.R
+++ b/outputs/reporting_app/ui.R
@@ -1,5 +1,6 @@
 ui <- function(request) {
   bslib::page_navbar(
+    id = "nav_main",
     title = shiny::tags$img(
       src = "logos/nnhip_logo.png",
       style = "height:60px;",
@@ -8,10 +9,13 @@ ui <- function(request) {
 
     # theming
     theme = bslib::bs_theme(brand = TRUE, card_bg = "white"),
-    header = shiny::tags$link(
-      rel = "stylesheet",
-      type = "text/css",
-      href = "_SUBrand.SyleSheet.css"
+    header = shiny::tagList(
+      shiny::tags$link(
+        rel = "stylesheet",
+        type = "text/css",
+        href = "_SUBrand.SyleSheet.css"
+      ),
+      conductor::useConductor()
     ),
 
     # documentation section ---------------------------------------------------
@@ -62,7 +66,8 @@ ui <- function(request) {
       value = "national_view",
       title = shiny::span(
         bsicons::bs_icon("map"),
-        "National view"
+        "National view",
+        class = "nav-national"
       ) |>
         bslib::tooltip(
           "National-level views of NNHIP data, showing key trends, patterns and progress across all Places.",
@@ -132,7 +137,8 @@ ui <- function(request) {
       value = "place_view",
       title = shiny::span(
         bsicons::bs_icon("pin-map"),
-        "Place view"
+        "Place view",
+        class = "nav-place"
       ) |>
         bslib::tooltip(
           "Place-level views of NNHIP data, showing local patterns, progress and variation across individual Places.",
@@ -141,6 +147,7 @@ ui <- function(request) {
       bslib::page_sidebar(
         # sidebar ----
         sidebar = bslib::sidebar(
+          id = "place_sidebar",
           shiny::div(
             # select a place (always visible)
             shiny::selectizeInput(
@@ -195,7 +202,11 @@ ui <- function(request) {
 
         # main ----
         bslib::card(
-          bslib::card_title(shiny::textOutput(outputId = "place_header")),
+          # bslib::card_title(shiny::textOutput(outputId = "place_header")),
+          shiny::div(
+            id = "place_header_title",
+            bslib::card_title(shiny::textOutput(outputId = "place_header")),
+          ),
           bslib::navset_card_tab(
             id = "place_tabs",
             full_screen = TRUE,
@@ -213,6 +224,19 @@ ui <- function(request) {
             mod_place_submission_ui("place_submission")
           )
         )
+      )
+    ),
+
+    # tour ----
+    bslib::nav_spacer(),
+    bslib::nav_item(
+      bslib::toolbar_input_button(
+        id = "start_tour",
+        label = "Take a tour",
+        show_label = TRUE,
+        icon = bsicons::bs_icon("question-circle"),
+        tooltip = "Take a tour of the dashboard",
+        class = "btn-primary"
       )
     )
   )


### PR DESCRIPTION
closes #52 
This pull request introduces an interactive guided tour to the NNHIP dashboard using the `{conductor}` package. The tour provides a structured onboarding experience for new users, helping them understand the dashboard's navigation, sidebars, view descriptions and interactive elements.

## Background
Feedback from early users highlighted that first-time visitors struggle to understand:
- how to navigate between sub-views and within each section
- where to find documentation
- how to use the sidebar controls (Place selector, bookmark button, etc.)
- how to interpret the view descriptions included in each module
- that tables and charts are interactive (sortable, hoverable, zoomable)
To address this, the dashboard now includes a guided tour that introduces the core layout and functionality in a clear, step-by-step format.

## What this PR adds
- A full `{conductor}` tour covering
  - Documentation menu
<img width="450" height="379" alt="image" src="https://github.com/user-attachments/assets/c1515931-6311-4814-91a7-6e782b807795" />

  - National View and its sub-navigation
<img width="1022" height="590" alt="image" src="https://github.com/user-attachments/assets/67652292-da8a-4117-81c1-96866c638217" />

  - Place View and its sub-navigation
  - Sidebar controls (Place selector, metric / month selectors, bookmark button, last updated panel)
<img width="666" height="940" alt="image" src="https://github.com/user-attachments/assets/77a3d060-63d8-4b76-b66f-e07a4ed4dfbc" />

  - Interactive elements (reactable tables and plotly charts)
<img width="982" height="984" alt="image" src="https://github.com/user-attachments/assets/1377df33-d15b-4bfe-8c6c-50cc180d3ce6" />

The tour is launched from a new **Take a tour** button in the top-right corner of the screen:
<img width="1279" height="52" alt="image" src="https://github.com/user-attachments/assets/d591f4e7-db1e-4dfa-8f82-a49b14ef3fa4" />

## Notes
- The tour is intentionally lightweight and focuses on orientation rather than detailed instructions
- Additional steps can be added later if new views or features are introduced.